### PR TITLE
Fixed serialization issue for `kind`.

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -44,6 +44,7 @@ pub struct MessageDialogOptions {
     pub title: Option<String>,
 
     /// The type of the dialog. Defaults to MessageDialogType::Info.
+    #[serde(rename(serialize = "type"))]
     pub kind: MessageDialogType,
 }
 


### PR DESCRIPTION
In `MessageDialogType`, `kind` is used instead of `type`. This change converts the field back to `type` when serialized.