### PR TITLE
Make window_label optional

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -18,7 +18,7 @@ pub struct Event<T> {
     /// Event payload
     pub payload: T,
     /// The label of the window that emitted this event
-    pub window_label: String,
+    pub window_label: Option<String>,
 }
 
 /// Emits an event to the backend.


### PR DESCRIPTION
`window_label` is null when emitting event for all windows using [tauri::Manager](https://docs.rs/tauri/1.2.3/tauri/trait.Manager.html#method.emit_all)