### PR TITLE
Fixing Opaque Return Type Conflict in `pick_folders` and `pick_files`  Method

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -30,6 +30,12 @@ struct DialogFilter<'a> {
     name: &'a str,
 }
 
+// Define a trait to represent the iterator of PathBuf items.
+trait PathBufIterator: Iterator<Item = PathBuf> {}
+
+// Implement the trait for the actual iterator type.
+impl<I: Iterator<Item = PathBuf>> PathBufIterator for I {}
+
 /// The file dialog builder.
 ///
 /// Constructs file picker dialogs that can select single/multiple files or directories.
@@ -167,16 +173,17 @@ impl<'a> FileDialogBuilder<'a> {
     /// ```
     ///
     /// Requires [`allowlist > dialog > open`](https://tauri.app/v1/api/config#dialogallowlistconfig.open) to be enabled.
-    pub async fn pick_files(&mut self) -> crate::Result<Option<impl Iterator<Item = PathBuf>>> {
+    pub async fn pick_files(&mut self) -> crate::Result<Option<Box<dyn PathBufIterator>>> {
         self.multiple = true;
-
+    
         let raw = inner::open(serde_wasm_bindgen::to_value(&self)?).await?;
-
+    
         if let Ok(files) = Array::try_from(raw) {
-            let files =
-                ArrayIterator::new(files).map(|raw| serde_wasm_bindgen::from_value(raw).unwrap());
-
-            Ok(Some(files))
+            let files = ArrayIterator::new(files)
+                .map(|raw| serde_wasm_bindgen::from_value(raw).unwrap())
+                .collect::<Vec<PathBuf>>();
+    
+            Ok(Some(Box::new(files.into_iter()) as Box<dyn PathBufIterator>))
         } else {
             Ok(None)
         }
@@ -218,17 +225,18 @@ impl<'a> FileDialogBuilder<'a> {
     /// ```
     ///
     /// Requires [`allowlist > dialog > open`](https://tauri.app/v1/api/config#dialogallowlistconfig.open) to be enabled.
-    pub async fn pick_folders(&mut self) -> crate::Result<Option<impl Iterator<Item = PathBuf>>> {
+    pub async fn pick_folders(&mut self) -> crate::Result<Option<impl PathBufIterator>> {
         self.directory = true;
         self.multiple = true;
-
+    
         let raw = inner::open(serde_wasm_bindgen::to_value(&self)?).await?;
-
+    
         if let Ok(files) = Array::try_from(raw) {
-            let files =
-                ArrayIterator::new(files).map(|raw| serde_wasm_bindgen::from_value(raw).unwrap());
-
-            Ok(Some(files))
+            let files = ArrayIterator::new(files)
+                .map(|raw| serde_wasm_bindgen::from_value(raw).unwrap())
+                .collect::<Vec<PathBuf>>();
+    
+            Ok(Some(Box::new(files.into_iter()) as Box<dyn PathBufIterator>))
         } else {
             Ok(None)
         }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -31,7 +31,7 @@ struct DialogFilter<'a> {
 }
 
 // Define a trait to represent the iterator of PathBuf items.
-trait PathBufIterator: Iterator<Item = PathBuf> {}
+pub trait PathBufIterator: Iterator<Item = PathBuf> {}
 
 // Implement the trait for the actual iterator type.
 impl<I: Iterator<Item = PathBuf>> PathBufIterator for I {}


### PR DESCRIPTION
Related to #27 

# Purpose
This pull request addresses an issue in the `pick_folders` and `pick_files`  methods of the `tauri-sys` crate, where a **conflicting opaque return type is causing build failures**. The changes proposed here aim to resolve the conflict and ensure the method returns a consistent and correct opaque type.

# Problem
The current implementation of the  `pick_folders` and `pick_files`  method returns an opaque type representing an iterator of `PathBuf` items. However, the closure passed to the map function within the method is causing a mismatch in the concrete return type for the same opaque type, leading to a build failure.

# Solution
To fix the conflict, we have explicitly defined a trait, `PathBufIterator`, to represent the iterator of `PathBuf `items. We have then implemented this trait for the actual iterator type, `std::vec::IntoIter<PathBuf>`, used within the method. By wrapping the closure inside a function that returns a trait object (`Box<dyn PathBufIterator>`), we ensure a consistent return type for the opaque type, resolving the conflict.

# Proposed Changes
Introduced the `PathBufIterator` trait to represent the iterator of `PathBuf` items.
Implemented the `PathBufIterator` trait for the actual iterator type used within the  `pick_folders` and `pick_files`  methods.
Modified the closure passed to the map function to explicitly return a trait object (`Box<dyn PathBufIterator>`).

# Testing
The crate `tauri-sys` has been build and tested on the three operating systems (Windows, Ubuntu, and macOS).  The tests verify that the method returns the correct iterator and that it integrates seamlessly with the existing codebase.

# Documentation

Only comments are provided. However, if the pull request get accepted I will provide proper documentation.
