### PR TITLE
Make bindings compatible with v2 plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smallvec",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -469,7 +469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -479,7 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -509,7 +509,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -520,7 +520,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -554,7 +554,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1158,7 +1158,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1759,7 +1759,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1947,7 +1947,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1961,7 +1961,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2070,7 +2070,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -2093,9 +2093,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2111,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2452,7 +2452,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2468,13 +2468,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2508,7 +2508,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2530,7 +2530,7 @@ checksum = "74064874e9f6a15f04c1f3cb627902d0e6b410abbf36668afa873c61889f1763"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2696,7 +2696,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2747,7 +2747,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2782,6 +2782,17 @@ name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2979,7 +2990,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -3049,6 +3060,7 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "serde-wasm-bindgen",
+ "serde_repr",
  "tauri-sys",
  "thiserror",
  "url",
@@ -3170,7 +3182,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3268,7 +3280,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3482,7 +3494,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -3516,7 +3528,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3628,7 +3640,7 @@ checksum = "eaebe196c01691db62e9e4ca52c5ef1e4fd837dcae27dae3ada599b5a8fd05ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -3733,7 +3745,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba01f98f509cb5dc05f4e5fc95e535f78260f15fea8fe1a8abdd08f774f1cee7"
 dependencies = [
- "syn",
+ "syn 1.0.103",
  "windows-tokens",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen-test = "0.3.33"
 all-features = true
 
 [features]
-all = ["app", "clipboard", "event", "mocks", "tauri", "window", "positioner", "process", "dialog", "os", "notification", "path", "updater", "global_shortcut", "fs"]
+all = ["app", "clipboard", "event", "mocks", "tauri", "window", "positioner", "process", "dialog", "os", "notification", "path", "updater", "global_shortcut", "fs", "store"]
 app = ["dep:semver"]
 clipboard = []
 dialog = []
@@ -39,6 +39,7 @@ os = []
 path = []
 positioner = []
 process = []
+store = ["dep:futures", "event"]
 tauri = ["dep:url"]
 updater = ["dep:futures", "event"]
 window = ["dep:futures", "event"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4.17"
 semver = {version = "1.0.14", optional = true, features = ["serde"]}
 serde = {version = "1.0.140", features = ["derive"]}
 serde-wasm-bindgen = "0.4.3"
+serde_repr = { version = "0.1.10", optional = true }
 thiserror = "1.0.37"
 url = {version = "2.3.1", optional = true, features = ["serde"]}
 wasm-bindgen = {version = "0.2.82", features = ["serde_json"]}
@@ -25,11 +26,12 @@ wasm-bindgen-test = "0.3.33"
 all-features = true
 
 [features]
-all = ["app", "clipboard", "event", "mocks", "tauri", "window", "positioner", "process", "dialog", "os", "notification", "path", "updater", "global_shortcut"]
+all = ["app", "clipboard", "event", "mocks", "tauri", "window", "positioner", "process", "dialog", "os", "notification", "path", "updater", "global_shortcut", "fs"]
 app = ["dep:semver"]
 clipboard = []
 dialog = []
 event = ["dep:futures"]
+fs = ["dep:serde_repr"]
 global_shortcut = []
 mocks = []
 notification = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm-bindgen-test = "0.3.33"
 all-features = true
 
 [features]
-all = ["app", "clipboard", "event", "mocks", "tauri", "window", "process", "dialog", "os", "notification", "path", "updater", "global_shortcut"]
+all = ["app", "clipboard", "event", "mocks", "tauri", "window", "positioner", "process", "dialog", "os", "notification", "path", "updater", "global_shortcut"]
 app = ["dep:semver"]
 clipboard = []
 dialog = []
@@ -35,6 +35,7 @@ mocks = []
 notification = []
 os = []
 path = []
+positioner = []
 process = []
 tauri = ["dep:url"]
 updater = ["dep:futures", "event"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 This crate is not yet published to crates.io, so you need to use it from git. You also need a global installation of [`esbuild`].
 
 ```toml
-tauri-sys = { git = "https://github.com/LetrixZ/tauri-sys" }
+tauri-sys = { git = "https://github.com/JonasKruckenberg/tauri-sys" }
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All modules are gated by accordingly named Cargo features. It is recommended you
 - **mocks**: Enables the `mocks` module.
 - **tauri**: Enables the `tauri` module.
 
-## Are we Tauri yet?
+## Are we Tauri v2s yet?
 
 These API bindings are not completely on-par with `@tauri-apps/api` yet, but here is the current status-quo:
 
@@ -68,10 +68,10 @@ These API bindings are not completely on-par with `@tauri-apps/api` yet, but her
 - [ ] `fs`
 - [x] `global_shortcut`
 - [ ] `http`
-- [x] `mocks`
+- [ ] `mocks`
 - [x] `notification`
 - [x] `os`
-- [x] `path`
+- [ ] `path`
 - [x] `process`
 - [ ] `shell`
 - [x] `tauri`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ fn main() {
 
 ## Plugins
 
-Some plugins are now separated from the Tauri core. https://github.com/tauri-apps/plugins-workspace\
+Some plugins are now separated from the Tauri core. https://github.com/tauri-apps/plugins-workspace
+
 `app`, `event`, `mocks`, `path` and `tauri` are still part of the core.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ These API bindings are not completely on-par with `@tauri-apps/api` and the rest
 - [x] `clipboard`
 - [x] `dialog`
 - [x] `event`
-- [ ] `fs`
+- [x] `fs`
 - [x] `global_shortcut`
 - [ ] `http`
 - [ ] `mocks`
@@ -73,8 +73,14 @@ These API bindings are not completely on-par with `@tauri-apps/api` and the rest
 - [x] `positioner`
 - [x] `process`
 - [ ] `shell`
+- [ ] `sql`
+- [ ] `store`
+- [ ] `stronghold`
 - [x] `tauri`
+- [ ] `upload`
 - [ ] `updater`
+- [ ] `websocket`
+- [ ] `window-state`
 - [x] `window`
 
 The current API also very closely mirrors the JS API even though that might not be the most ergonomic choice, ideas for improving the API with quality-of-life features beyond the regular JS API interface are very welcome.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ These API bindings are not completely on-par with `@tauri-apps/api` and the rest
 - [x] `process`
 - [ ] `shell`
 - [ ] `sql`
-- [ ] `store`
+- [x] `store`
 - [ ] `stronghold`
 - [x] `tauri`
 - [ ] `upload`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 This crate is not yet published to crates.io, so you need to use it from git. You also need a global installation of [`esbuild`].
 
 ```toml
-tauri-sys = { git = "https://github.com/JonasKruckenberg/tauri-sys" }
+tauri-sys = { git = "https://github.com/LetrixZ/tauri-sys" }
 ```
 
 ## Usage
@@ -44,21 +44,18 @@ fn main() {
 }
 ```
 
+## Plugins
+
+Some plugins are now separated from the Tauri core. https://github.com/tauri-apps/plugins-workspace\
+`app`, `event`, `mocks`, `path` and `tauri` are still part of the core.
+
 ## Features
 
-All modules are gated by accordingly named Cargo features. It is recommended you keep this synced with the features enabled in your [Tauri Allowlist] but no automated tool for this exists (yet).
+Bindings are behind features. Use `all` to enable all features or use the name of the plugin as the feature to enable it.
 
-- **all**: Enables all modules.
-- **app**: Enables the `app` module.
-- **clipboard**: Enables the `clipboard` module.
-- **dialog**: Enables the `dialog` module.
-- **event**: Enables the `event` module.
-- **mocks**: Enables the `mocks` module.
-- **tauri**: Enables the `tauri` module.
+## Are we Tauri v2 yet?
 
-## Are we Tauri v2s yet?
-
-These API bindings are not completely on-par with `@tauri-apps/api` yet, but here is the current status-quo:
+These API bindings are not completely on-par with `@tauri-apps/api` and the rest of the plugins yet, but here is the current status-quo:
 
 - [x] `app`
 - [ ] `cli`
@@ -72,6 +69,7 @@ These API bindings are not completely on-par with `@tauri-apps/api` yet, but her
 - [x] `notification`
 - [x] `os`
 - [ ] `path`
+- [x] `positioner`
 - [x] `process`
 - [ ] `shell`
 - [x] `tauri`

--- a/examples/test/src/window.rs
+++ b/examples/test/src/window.rs
@@ -2,7 +2,7 @@ use anyhow::ensure;
 use tauri_sys::window;
 
 pub async fn create_window() -> anyhow::Result<()> {
-    let win = window::WebviewWindowBuilder::new("foo-win")
+    let win = window::WindowBuilder::new("foo-win")
         .set_url("/")
         .build()
         .await?;

--- a/src/app.js
+++ b/src/app.js
@@ -1,91 +1,21 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/app.ts
 async function getVersion() {
-  return invokeTauriCommand({
-    __tauriModule: "App",
-    message: {
-      cmd: "getAppVersion"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:app|version");
 }
+
 async function getName() {
-  return invokeTauriCommand({
-    __tauriModule: "App",
-    message: {
-      cmd: "getAppName"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:app|name");
 }
+
 async function getTauriVersion() {
-  return invokeTauriCommand({
-    __tauriModule: "App",
-    message: {
-      cmd: "getTauriVersion"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:app|tauri_version");
 }
+
 async function show() {
-  return invokeTauriCommand({
-    __tauriModule: "App",
-    message: {
-      cmd: "show"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:app|show");
 }
+
 async function hide() {
-  return invokeTauriCommand({
-    __tauriModule: "App",
-    message: {
-      cmd: "hide"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:app|hide");
 }
-export {
-  getName,
-  getTauriVersion,
-  getVersion,
-  hide,
-  show
-};
+
+export { getName, getVersion, getTauriVersion, show, hide };

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke } = window.__TAURI__.primitives;
 
 async function getVersion() {
   return invoke("plugin:app|version");

--- a/src/app.js
+++ b/src/app.js
@@ -1,21 +1,23 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function getVersion() {
-  return window.__TAURI_INVOKE__("plugin:app|version");
+  return invoke("plugin:app|version");
 }
 
 async function getName() {
-  return window.__TAURI_INVOKE__("plugin:app|name");
+  return invoke("plugin:app|name");
 }
 
 async function getTauriVersion() {
-  return window.__TAURI_INVOKE__("plugin:app|tauri_version");
+  return invoke("plugin:app|tauri_version");
 }
 
 async function show() {
-  return window.__TAURI_INVOKE__("plugin:app|show");
+  return invoke("plugin:app|show");
 }
 
 async function hide() {
-  return window.__TAURI_INVOKE__("plugin:app|hide");
+  return invoke("plugin:app|hide");
 }
 
 export { getName, getVersion, getTauriVersion, show, hide };

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,20 +1,4 @@
 //! Get application metadata.
-//! 
-//! he APIs must be added to tauri.allowlist.app in tauri.conf.json:
-//! ```json
-//! {
-//!     "tauri": {
-//!         "allowlist": {
-//!             "app": {
-//!                 "all": true, // enable all app APIs
-//!                 "show": true,
-//!                 "hide": true
-//!             }
-//!         }
-//!     }
-//! }
-//! ```
-//! It is recommended to allowlist only the APIs you use for optimal bundle size and security.
 
 use semver::Version;
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,55 +1,5 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/cli.ts
 async function getMatches() {
-  return invokeTauriCommand({
-    __tauriModule: "Cli",
-    message: {
-      cmd: "cliMatches"
-    }
-  });
+  return await window.__TAURI_INVOKE__("plugin:cli|cli_matches");
 }
-export {
-  getMatches
-};
+
+export { getMatches };

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,7 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function getMatches() {
-  return await window.__TAURI_INVOKE__("plugin:cli|cli_matches");
+  return await invoke("plugin:cli|cli_matches");
 }
 
 export { getMatches };

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke } = window.__TAURI__.primitives;
 
 async function getMatches() {
   return await invoke("plugin:cli|cli_matches");

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,5 +1,7 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function writeText(text, opts) {
-  return window.__TAURI_INVOKE__("plugin:clipboard|write", {
+  return invoke("plugin:clipboard|write", {
     data: {
       kind: "PlainText",
       options: {
@@ -11,7 +13,7 @@ async function writeText(text, opts) {
 }
 
 async function readText() {
-  const kind = await window.__TAURI_INVOKE__("plugin:clipboard|read");
+  const kind = await invoke("plugin:clipboard|read");
   return kind.options;
 }
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,66 +1,18 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
+async function writeText(text, opts) {
+  return window.__TAURI_INVOKE__("plugin:clipboard|write", {
+    data: {
+      kind: "PlainText",
+      options: {
+        label: opts?.label,
+        text,
+      },
     },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
   });
 }
 
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/clipboard.ts
-async function writeText(text) {
-  return invokeTauriCommand({
-    __tauriModule: "Clipboard",
-    message: {
-      cmd: "writeText",
-      data: text
-    }
-  });
-}
 async function readText() {
-  return invokeTauriCommand({
-    __tauriModule: "Clipboard",
-    message: {
-      cmd: "readText",
-      data: null
-    }
-  });
+  const kind = await window.__TAURI_INVOKE__("plugin:clipboard|read");
+  return kind.options;
 }
-export {
-  readText,
-  writeText
-};
+
+export { readText, writeText };

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke } = window.__TAURI__.primitives;
 
 async function writeText(text, opts) {
   return invoke("plugin:clipboard|write", {

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke } = window.__TAURI__.primitives;
 
 async function open(options) {
   if (typeof options === "object") {

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -1,111 +1,94 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/dialog.ts
 async function open(options = {}) {
   if (typeof options === "object") {
     Object.freeze(options);
   }
-  return invokeTauriCommand({
-    __tauriModule: "Dialog",
-    message: {
-      cmd: "openDialog",
-      options
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:dialog|open", { options });
 }
+
 async function save(options = {}) {
   if (typeof options === "object") {
     Object.freeze(options);
   }
-  return invokeTauriCommand({
-    __tauriModule: "Dialog",
-    message: {
-      cmd: "saveDialog",
-      options
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:dialog|save", { options });
 }
-async function message(message2, options) {
+
+async function message(message, options) {
+  var _a, _b;
   const opts = typeof options === "string" ? { title: options } : options;
-  return invokeTauriCommand({
-    __tauriModule: "Dialog",
-    message: {
-      cmd: "messageDialog",
-      message: message2.toString(),
-      title: opts?.title?.toString(),
-      type: opts?.type
-    }
+  return window.__TAURI_INVOKE__("plugin:dialog|message", {
+    message: message.toString(),
+    title:
+      (_a = opts === null || opts === void 0 ? void 0 : opts.title) === null ||
+      _a === void 0
+        ? void 0
+        : _a.toString(),
+    type: opts === null || opts === void 0 ? void 0 : opts.type,
+    okButtonLabel:
+      (_b = opts === null || opts === void 0 ? void 0 : opts.okLabel) ===
+        null || _b === void 0
+        ? void 0
+        : _b.toString(),
   });
 }
-async function ask(message2, options) {
+
+async function ask(message, options) {
+  var _a, _b, _c, _d, _e;
   const opts = typeof options === "string" ? { title: options } : options;
-  return invokeTauriCommand({
-    __tauriModule: "Dialog",
-    message: {
-      cmd: "askDialog",
-      message: message2.toString(),
-      title: opts?.title?.toString(),
-      type: opts?.type
-    }
+  return window.__TAURI_INVOKE__("plugin:dialog|ask", {
+    message: message.toString(),
+    title:
+      (_a = opts === null || opts === void 0 ? void 0 : opts.title) === null ||
+      _a === void 0
+        ? void 0
+        : _a.toString(),
+    type: opts === null || opts === void 0 ? void 0 : opts.type,
+    okButtonLabel:
+      (_c =
+        (_b = opts === null || opts === void 0 ? void 0 : opts.okLabel) ===
+          null || _b === void 0
+          ? void 0
+          : _b.toString()) !== null && _c !== void 0
+        ? _c
+        : "Yes",
+    cancelButtonLabel:
+      (_e =
+        (_d = opts === null || opts === void 0 ? void 0 : opts.cancelLabel) ===
+          null || _d === void 0
+          ? void 0
+          : _d.toString()) !== null && _e !== void 0
+        ? _e
+        : "No",
   });
 }
-async function confirm(message2, options) {
+
+async function confirm(message, options) {
+  var _a, _b, _c, _d, _e;
   const opts = typeof options === "string" ? { title: options } : options;
-  return invokeTauriCommand({
-    __tauriModule: "Dialog",
-    message: {
-      cmd: "confirmDialog",
-      message: message2.toString(),
-      title: opts?.title?.toString(),
-      type: opts?.type
-    }
+  return window.__TAURI_INVOKE__("plugin:dialog|confirm", {
+    message: message.toString(),
+    title:
+      (_a = opts === null || opts === void 0 ? void 0 : opts.title) === null ||
+      _a === void 0
+        ? void 0
+        : _a.toString(),
+    type: opts === null || opts === void 0 ? void 0 : opts.type,
+    okButtonLabel:
+      (_c =
+        (_b = opts === null || opts === void 0 ? void 0 : opts.okLabel) ===
+          null || _b === void 0
+          ? void 0
+          : _b.toString()) !== null && _c !== void 0
+        ? _c
+        : "Ok",
+    cancelButtonLabel:
+      (_e =
+        (_d = opts === null || opts === void 0 ? void 0 : opts.cancelLabel) ===
+          null || _d === void 0
+          ? void 0
+          : _d.toString()) !== null && _e !== void 0
+        ? _e
+        : "Cancel",
   });
 }
-export {
-  ask,
-  confirm,
-  message,
-  open,
-  save
-};
+
+export { ask, confirm, message, open, save };

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -1,9 +1,11 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function open(options) {
   if (typeof options === "object") {
     Object.freeze(options);
   }
 
-  return window.__TAURI_INVOKE__("plugin:dialog|open", { options });
+  return invoke("plugin:dialog|open", { options });
 }
 
 async function open(options) {
@@ -11,7 +13,7 @@ async function open(options) {
     Object.freeze(options);
   }
 
-  return window.__TAURI_INVOKE__("plugin:dialog|open", { options });
+  return invoke("plugin:dialog|open", { options });
 }
 
 async function save(options) {
@@ -19,12 +21,12 @@ async function save(options) {
     Object.freeze(options);
   }
 
-  return window.__TAURI_INVOKE__("plugin:dialog|save", { options });
+  return invoke("plugin:dialog|save", { options });
 }
 
 async function message(message, options) {
   const opts = typeof options === "string" ? { title: options } : options;
-  return window.__TAURI_INVOKE__("plugin:dialog|message", {
+  return invoke("plugin:dialog|message", {
     message: message.toString(),
     title: opts?.title?.toString(),
     type: opts?.type,
@@ -34,7 +36,7 @@ async function message(message, options) {
 
 async function ask(message, options) {
   const opts = typeof options === "string" ? { title: options } : options;
-  return window.__TAURI_INVOKE__("plugin:dialog|ask", {
+  return invoke("plugin:dialog|ask", {
     message: message.toString(),
     title: opts?.title?.toString(),
     type: opts?.type,
@@ -45,7 +47,7 @@ async function ask(message, options) {
 
 async function confirm(message, options) {
   const opts = typeof options === "string" ? { title: options } : options;
-  return window.__TAURI_INVOKE__("plugin:dialog|confirm", {
+  return invoke("plugin:dialog|confirm", {
     message: message.toString(),
     title: opts?.title?.toString(),
     type: opts?.type,

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -1,94 +1,57 @@
-async function open(options = {}) {
+async function open(options) {
   if (typeof options === "object") {
     Object.freeze(options);
   }
+
   return window.__TAURI_INVOKE__("plugin:dialog|open", { options });
 }
 
-async function save(options = {}) {
+async function open(options) {
   if (typeof options === "object") {
     Object.freeze(options);
   }
+
+  return window.__TAURI_INVOKE__("plugin:dialog|open", { options });
+}
+
+async function save(options) {
+  if (typeof options === "object") {
+    Object.freeze(options);
+  }
+
   return window.__TAURI_INVOKE__("plugin:dialog|save", { options });
 }
 
 async function message(message, options) {
-  var _a, _b;
   const opts = typeof options === "string" ? { title: options } : options;
   return window.__TAURI_INVOKE__("plugin:dialog|message", {
     message: message.toString(),
-    title:
-      (_a = opts === null || opts === void 0 ? void 0 : opts.title) === null ||
-      _a === void 0
-        ? void 0
-        : _a.toString(),
-    type: opts === null || opts === void 0 ? void 0 : opts.type,
-    okButtonLabel:
-      (_b = opts === null || opts === void 0 ? void 0 : opts.okLabel) ===
-        null || _b === void 0
-        ? void 0
-        : _b.toString(),
+    title: opts?.title?.toString(),
+    type: opts?.type,
+    okButtonLabel: opts?.okLabel?.toString(),
   });
 }
 
 async function ask(message, options) {
-  var _a, _b, _c, _d, _e;
   const opts = typeof options === "string" ? { title: options } : options;
   return window.__TAURI_INVOKE__("plugin:dialog|ask", {
     message: message.toString(),
-    title:
-      (_a = opts === null || opts === void 0 ? void 0 : opts.title) === null ||
-      _a === void 0
-        ? void 0
-        : _a.toString(),
-    type: opts === null || opts === void 0 ? void 0 : opts.type,
-    okButtonLabel:
-      (_c =
-        (_b = opts === null || opts === void 0 ? void 0 : opts.okLabel) ===
-          null || _b === void 0
-          ? void 0
-          : _b.toString()) !== null && _c !== void 0
-        ? _c
-        : "Yes",
-    cancelButtonLabel:
-      (_e =
-        (_d = opts === null || opts === void 0 ? void 0 : opts.cancelLabel) ===
-          null || _d === void 0
-          ? void 0
-          : _d.toString()) !== null && _e !== void 0
-        ? _e
-        : "No",
+    title: opts?.title?.toString(),
+    type: opts?.type,
+    okButtonLabel: opts?.okLabel?.toString(),
+    cancelButtonLabel: opts?.cancelLabel?.toString(),
   });
 }
 
 async function confirm(message, options) {
-  var _a, _b, _c, _d, _e;
   const opts = typeof options === "string" ? { title: options } : options;
   return window.__TAURI_INVOKE__("plugin:dialog|confirm", {
     message: message.toString(),
-    title:
-      (_a = opts === null || opts === void 0 ? void 0 : opts.title) === null ||
-      _a === void 0
-        ? void 0
-        : _a.toString(),
-    type: opts === null || opts === void 0 ? void 0 : opts.type,
-    okButtonLabel:
-      (_c =
-        (_b = opts === null || opts === void 0 ? void 0 : opts.okLabel) ===
-          null || _b === void 0
-          ? void 0
-          : _b.toString()) !== null && _c !== void 0
-        ? _c
-        : "Ok",
-    cancelButtonLabel:
-      (_e =
-        (_d = opts === null || opts === void 0 ? void 0 : opts.cancelLabel) ===
-          null || _d === void 0
-          ? void 0
-          : _d.toString()) !== null && _e !== void 0
-        ? _e
-        : "Cancel",
+    title: opts?.title?.toString(),
+    type: opts?.type,
+    okButtonLabel: opts?.okLabel?.toString(),
+    cancelButtonLabel: opts?.cancelLabel?.toString(),
   });
 }
 
-export { ask, confirm, message, open, save };
+export { open, save, message, ask, confirm };

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -270,7 +270,7 @@ pub struct MessageDialogBuilder {
     #[serde(rename = "okLabel")]
     ok_button_label: Option<String>,
     #[serde(rename = "cancelLabel")]
-    cancel_button_label: Option<String>
+    cancel_button_label: Option<String>,
 }
 
 impl<'a> MessageDialogBuilder {
@@ -312,11 +312,35 @@ impl<'a> MessageDialogBuilder {
         self
     }
 
+    /// Set the label for the Ok button of the dialog.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tauri_sys::dialog::{MessageDialogBuilder};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let _builder = MessageDialogBuilder::new().set_ok_label("Continue");
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_ok_label(&mut self, label: String) -> &mut Self {
         self.ok_button_label = Some(label);
         self
     }
 
+    /// Set the label for the cancel button of the dialog.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tauri_sys::dialog::{MessageDialogBuilder};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let _builder = MessageDialogBuilder::new().set_cancel_label("Stop");
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_cancel_label(&mut self, label: String) -> &mut Self {
         self.cancel_button_label = Some(label);
         self

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1,8 +1,15 @@
+//! Native system dialogs for opening and saving files.
+//!
+//! The Dialog plugin must be installed and configured.
+//! ```rust
+//! tauri::Builder::default()
+//!   .plugin(tauri_plugin_dialog::init())
+//!   .run(tauri::generate_context!())
+//! ```
 use js_sys::Array;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-use crate::utils::ArrayIterator;
 #[derive(Debug, Clone, Copy, Hash, Serialize)]
 struct DialogFilter<'a> {
     extensions: &'a [&'a str],

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
+use std::path::PathBuf;
 use wasm_bindgen::JsValue;
-
 
 #[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
 pub enum Error {
@@ -9,7 +9,10 @@ pub enum Error {
     Serde(String),
     #[cfg(any(feature = "event", feature = "window"))]
     #[error("Oneshot cancelled: {0}")]
-    OneshotCanceled(#[from] futures::channel::oneshot::Canceled)
+    OneshotCanceled(#[from] futures::channel::oneshot::Canceled),
+    #[cfg(feature = "fs")]
+    #[error("could not convert path to string")]
+    Utf8(PathBuf),
 }
 
 impl From<serde_wasm_bindgen::Error> for Error {

--- a/src/event.js
+++ b/src/event.js
@@ -1,19 +1,20 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function _unlisten(event, eventId) {
-  await window.__TAURI_INVOKE__("plugin:event|unlisten", {
+  await invoke("plugin:event|unlisten", {
     event,
     eventId,
   });
 }
 
 async function listen(event, handler, options) {
-  return window.__TAURI_INVOKE__("plugin:event|listen", {
-      event,
-      windowLabel: options?.target,
-      handler: window.__TAURI__.transformCallback(handler),
-    })
-    .then((eventId) => {
-      return async () => _unlisten(event, eventId);
-    });
+  return invoke("plugin:event|listen", {
+    event,
+    windowLabel: options?.target,
+    handler: window.__TAURI__.transformCallback(handler),
+  }).then((eventId) => {
+    return async () => _unlisten(event, eventId);
+  });
 }
 
 async function once(event, handler, options) {
@@ -28,7 +29,7 @@ async function once(event, handler, options) {
 }
 
 async function emit(event, payload, options) {
-  await window.__TAURI_INVOKE__("plugin:event|emit", {
+  await invoke("plugin:event|emit", {
     event,
     windowLabel: options?.target,
     payload,

--- a/src/event.js
+++ b/src/event.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke, transformCallback } = window.__TAURI__.primitives;
 
 async function _unlisten(event, eventId) {
   await invoke("plugin:event|unlisten", {
@@ -11,7 +11,7 @@ async function listen(event, handler, options) {
   return invoke("plugin:event|listen", {
     event,
     windowLabel: options?.target,
-    handler: window.__TAURI__.transformCallback(handler),
+    handler: transformCallback(handler),
   }).then((eventId) => {
     return async () => _unlisten(event, eventId);
   });

--- a/src/event.js
+++ b/src/event.js
@@ -1,123 +1,38 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once3 = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once3) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/helpers/event.ts
 async function _unlisten(event, eventId) {
-  return invokeTauriCommand({
-    __tauriModule: "Event",
-    message: {
-      cmd: "unlisten",
-      event,
-      eventId
-    }
-  });
-}
-async function emit(event, windowLabel, payload) {
-  await invokeTauriCommand({
-    __tauriModule: "Event",
-    message: {
-      cmd: "emit",
-      event,
-      windowLabel,
-      payload
-    }
-  });
-}
-async function listen(event, windowLabel, handler) {
-  return invokeTauriCommand({
-    __tauriModule: "Event",
-    message: {
-      cmd: "listen",
-      event,
-      windowLabel,
-      handler: transformCallback(handler)
-    }
-  }).then((eventId) => {
-    return async () => _unlisten(event, eventId);
-  });
-}
-async function once(event, windowLabel, handler) {
-  return listen(event, windowLabel, (eventData) => {
-    handler(eventData);
-    _unlisten(event, eventData.id).catch(() => {
-    });
+  await window.__TAURI_INVOKE__("plugin:event|unlisten", {
+    event,
+    eventId,
   });
 }
 
-// tauri/tooling/api/src/event.ts
-var TauriEvent = /* @__PURE__ */ ((TauriEvent2) => {
-  TauriEvent2["WINDOW_RESIZED"] = "tauri://resize";
-  TauriEvent2["WINDOW_MOVED"] = "tauri://move";
-  TauriEvent2["WINDOW_CLOSE_REQUESTED"] = "tauri://close-requested";
-  TauriEvent2["WINDOW_CREATED"] = "tauri://window-created";
-  TauriEvent2["WINDOW_DESTROYED"] = "tauri://destroyed";
-  TauriEvent2["WINDOW_FOCUS"] = "tauri://focus";
-  TauriEvent2["WINDOW_BLUR"] = "tauri://blur";
-  TauriEvent2["WINDOW_SCALE_FACTOR_CHANGED"] = "tauri://scale-change";
-  TauriEvent2["WINDOW_THEME_CHANGED"] = "tauri://theme-changed";
-  TauriEvent2["WINDOW_FILE_DROP"] = "tauri://file-drop";
-  TauriEvent2["WINDOW_FILE_DROP_HOVER"] = "tauri://file-drop-hover";
-  TauriEvent2["WINDOW_FILE_DROP_CANCELLED"] = "tauri://file-drop-cancelled";
-  TauriEvent2["MENU"] = "tauri://menu";
-  TauriEvent2["CHECK_UPDATE"] = "tauri://update";
-  TauriEvent2["UPDATE_AVAILABLE"] = "tauri://update-available";
-  TauriEvent2["INSTALL_UPDATE"] = "tauri://update-install";
-  TauriEvent2["STATUS_UPDATE"] = "tauri://update-status";
-  TauriEvent2["DOWNLOAD_PROGRESS"] = "tauri://update-download-progress";
-  return TauriEvent2;
-})(TauriEvent || {});
-async function listen2(event, handler) {
-  return listen(event, null, handler);
+async function listen(event, handler, options) {
+  return window.__TAURI_INVOKE__("plugin:event|listen", {
+      event,
+      windowLabel: options?.target,
+      handler: window.__TAURI__.transformCallback(handler),
+    })
+    .then((eventId) => {
+      return async () => _unlisten(event, eventId);
+    });
 }
-async function once2(event, handler) {
-  return once(event, null, handler);
+
+async function once(event, handler, options) {
+  return listen(
+    event,
+    (eventData) => {
+      handler(eventData);
+      _unlisten(event, eventData.id).catch(() => {});
+    },
+    options
+  );
 }
-async function emit2(event, payload) {
-  return emit(event, void 0, payload);
+
+async function emit(event, payload, options) {
+  await window.__TAURI_INVOKE__("plugin:event|emit", {
+    event,
+    windowLabel: options?.target,
+    payload,
+  });
 }
-export {
-  TauriEvent,
-  emit2 as emit,
-  listen2 as listen,
-  once2 as once
-};
+
+export { listen, once, emit };

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,7 +5,6 @@ use futures::{
     Future, FutureExt, Stream, StreamExt,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_wasm_bindgen::to_value;
 use std::fmt::Debug;
 use wasm_bindgen::{prelude::Closure, JsValue};
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -156,7 +156,7 @@ impl<T> Stream for Listen<T> {
 /// }
 ///
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// const event = once::<LoadedPayload>("loaded", EventOptions::new()).await?;
+/// let event = once::<LoadedPayload>("loaded", EventOptions::new()).await?;
 ///
 /// console::log_1!(&format!("App is loaded, loggedIn: {}, token: {}", event.payload.logged_in, event.payload.token).into());
 /// # Ok(())

--- a/src/event.rs
+++ b/src/event.rs
@@ -83,6 +83,7 @@ pub async fn emit<T: Serialize>(
 /// # Example
 ///
 /// ```rust,no_run
+/// use futures::StreamExt;
 /// use tauri_api::event::{listen, EventOptions};
 /// use web_sys::console;
 ///

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke } = window.__TAURI__.primitives;
 
 async function readTextFile(filePath, options = {}) {
   return await invoke("plugin:fs|read_text_file", {

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,96 +1,19 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/fs.ts
-var BaseDirectory = /* @__PURE__ */ ((BaseDirectory2) => {
-  BaseDirectory2[BaseDirectory2["Audio"] = 1] = "Audio";
-  BaseDirectory2[BaseDirectory2["Cache"] = 2] = "Cache";
-  BaseDirectory2[BaseDirectory2["Config"] = 3] = "Config";
-  BaseDirectory2[BaseDirectory2["Data"] = 4] = "Data";
-  BaseDirectory2[BaseDirectory2["LocalData"] = 5] = "LocalData";
-  BaseDirectory2[BaseDirectory2["Desktop"] = 6] = "Desktop";
-  BaseDirectory2[BaseDirectory2["Document"] = 7] = "Document";
-  BaseDirectory2[BaseDirectory2["Download"] = 8] = "Download";
-  BaseDirectory2[BaseDirectory2["Executable"] = 9] = "Executable";
-  BaseDirectory2[BaseDirectory2["Font"] = 10] = "Font";
-  BaseDirectory2[BaseDirectory2["Home"] = 11] = "Home";
-  BaseDirectory2[BaseDirectory2["Picture"] = 12] = "Picture";
-  BaseDirectory2[BaseDirectory2["Public"] = 13] = "Public";
-  BaseDirectory2[BaseDirectory2["Runtime"] = 14] = "Runtime";
-  BaseDirectory2[BaseDirectory2["Template"] = 15] = "Template";
-  BaseDirectory2[BaseDirectory2["Video"] = 16] = "Video";
-  BaseDirectory2[BaseDirectory2["Resource"] = 17] = "Resource";
-  BaseDirectory2[BaseDirectory2["App"] = 18] = "App";
-  BaseDirectory2[BaseDirectory2["Log"] = 19] = "Log";
-  BaseDirectory2[BaseDirectory2["Temp"] = 20] = "Temp";
-  BaseDirectory2[BaseDirectory2["AppConfig"] = 21] = "AppConfig";
-  BaseDirectory2[BaseDirectory2["AppData"] = 22] = "AppData";
-  BaseDirectory2[BaseDirectory2["AppLocalData"] = 23] = "AppLocalData";
-  BaseDirectory2[BaseDirectory2["AppCache"] = 24] = "AppCache";
-  BaseDirectory2[BaseDirectory2["AppLog"] = 25] = "AppLog";
-  return BaseDirectory2;
-})(BaseDirectory || {});
 async function readTextFile(filePath, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "readTextFile",
-      path: filePath,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|read_text_file", {
+    path: filePath,
+    options,
   });
 }
+
 async function readBinaryFile(filePath, options = {}) {
-  const arr = await invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "readFile",
-      path: filePath,
-      options
-    }
+  const arr = await window.__TAURI_INVOKE__("plugin:fs|read_file", {
+    path: filePath,
+    options,
   });
+
   return Uint8Array.from(arr);
 }
+
 async function writeTextFile(path, contents, options) {
   if (typeof options === "object") {
     Object.freeze(options);
@@ -98,6 +21,7 @@ async function writeTextFile(path, contents, options) {
   if (typeof path === "object") {
     Object.freeze(path);
   }
+
   const file = { path: "", contents: "" };
   let fileOptions = options;
   if (typeof path === "string") {
@@ -106,21 +30,20 @@ async function writeTextFile(path, contents, options) {
     file.path = path.path;
     file.contents = path.contents;
   }
+
   if (typeof contents === "string") {
     file.contents = contents ?? "";
   } else {
     fileOptions = contents;
   }
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "writeFile",
-      path: file.path,
-      contents: Array.from(new TextEncoder().encode(file.contents)),
-      options: fileOptions
-    }
+
+  return await window.__TAURI_INVOKE__("plugin:fs|write_file", {
+    path: file.path,
+    contents: Array.from(new TextEncoder().encode(file.contents)),
+    options: fileOptions,
   });
 }
+
 async function writeBinaryFile(path, contents, options) {
   if (typeof options === "object") {
     Object.freeze(options);
@@ -128,6 +51,7 @@ async function writeBinaryFile(path, contents, options) {
   if (typeof path === "object") {
     Object.freeze(path);
   }
+
   const file = { path: "", contents: [] };
   let fileOptions = options;
   if (typeof path === "string") {
@@ -136,108 +60,86 @@ async function writeBinaryFile(path, contents, options) {
     file.path = path.path;
     file.contents = path.contents;
   }
+
   if (contents && "dir" in contents) {
     fileOptions = contents;
   } else if (typeof path === "string") {
     file.contents = contents ?? [];
   }
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "writeFile",
-      path: file.path,
-      contents: Array.from(
-        file.contents instanceof ArrayBuffer ? new Uint8Array(file.contents) : file.contents
-      ),
-      options: fileOptions
-    }
+
+  return await window.__TAURI_INVOKE__("plugin:fs|write_file", {
+    path: file.path,
+    contents: Array.from(file.contents instanceof ArrayBuffer ? new Uint8Array(file.contents) : file.contents),
+    options: fileOptions,
   });
 }
+
 async function readDir(dir, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "readDir",
-      path: dir,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|read_dir", {
+    path: dir,
+    options,
   });
 }
+
 async function createDir(dir, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "createDir",
-      path: dir,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|create_dir", {
+    path: dir,
+    options,
   });
 }
+
 async function removeDir(dir, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "removeDir",
-      path: dir,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|remove_dir", {
+    path: dir,
+    options,
   });
 }
+
 async function copyFile(source, destination, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "copyFile",
-      source,
-      destination,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|copy_file", {
+    source,
+    destination,
+    options,
   });
 }
+
 async function removeFile(file, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "removeFile",
-      path: file,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|remove_file", {
+    path: file,
+    options,
   });
 }
+
 async function renameFile(oldPath, newPath, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "renameFile",
-      oldPath,
-      newPath,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|rename_file", {
+    oldPath,
+    newPath,
+    options,
   });
 }
+
 async function exists(path, options = {}) {
-  return invokeTauriCommand({
-    __tauriModule: "Fs",
-    message: {
-      cmd: "exists",
-      path,
-      options
-    }
+  return await window.__TAURI_INVOKE__("plugin:fs|exists", { path, options });
+}
+
+async function metadata(path) {
+  return await window.__TAURI_INVOKE__("plugin:fs|metadata", {
+    path,
   });
 }
+
 export {
-  BaseDirectory,
-  BaseDirectory as Dir,
-  copyFile,
-  createDir,
-  exists,
-  readBinaryFile,
-  readDir,
   readTextFile,
+  readBinaryFile,
+  writeTextFile,
+  writeTextFile as writeFile,
+  writeBinaryFile,
+  readDir,
+  createDir,
   removeDir,
+  copyFile,
   removeFile,
   renameFile,
-  writeBinaryFile,
-  writeTextFile as writeFile,
-  writeTextFile
+  exists,
+  metadata,
 };

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,12 +1,14 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function readTextFile(filePath, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|read_text_file", {
+  return await invoke("plugin:fs|read_text_file", {
     path: filePath,
     options,
   });
 }
 
 async function readBinaryFile(filePath, options = {}) {
-  const arr = await window.__TAURI_INVOKE__("plugin:fs|read_file", {
+  const arr = await invoke("plugin:fs|read_file", {
     path: filePath,
     options,
   });
@@ -37,7 +39,7 @@ async function writeTextFile(path, contents, options) {
     fileOptions = contents;
   }
 
-  return await window.__TAURI_INVOKE__("plugin:fs|write_file", {
+  return await invoke("plugin:fs|write_file", {
     path: file.path,
     contents: Array.from(new TextEncoder().encode(file.contents)),
     options: fileOptions,
@@ -67,7 +69,7 @@ async function writeBinaryFile(path, contents, options) {
     file.contents = contents ?? [];
   }
 
-  return await window.__TAURI_INVOKE__("plugin:fs|write_file", {
+  return await invoke("plugin:fs|write_file", {
     path: file.path,
     contents: Array.from(file.contents instanceof ArrayBuffer ? new Uint8Array(file.contents) : file.contents),
     options: fileOptions,
@@ -75,28 +77,28 @@ async function writeBinaryFile(path, contents, options) {
 }
 
 async function readDir(dir, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|read_dir", {
+  return await invoke("plugin:fs|read_dir", {
     path: dir,
     options,
   });
 }
 
 async function createDir(dir, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|create_dir", {
+  return await invoke("plugin:fs|create_dir", {
     path: dir,
     options,
   });
 }
 
 async function removeDir(dir, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|remove_dir", {
+  return await invoke("plugin:fs|remove_dir", {
     path: dir,
     options,
   });
 }
 
 async function copyFile(source, destination, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|copy_file", {
+  return await invoke("plugin:fs|copy_file", {
     source,
     destination,
     options,
@@ -104,14 +106,14 @@ async function copyFile(source, destination, options = {}) {
 }
 
 async function removeFile(file, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|remove_file", {
+  return await invoke("plugin:fs|remove_file", {
     path: file,
     options,
   });
 }
 
 async function renameFile(oldPath, newPath, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|rename_file", {
+  return await invoke("plugin:fs|rename_file", {
     oldPath,
     newPath,
     options,
@@ -119,11 +121,11 @@ async function renameFile(oldPath, newPath, options = {}) {
 }
 
 async function exists(path, options = {}) {
-  return await window.__TAURI_INVOKE__("plugin:fs|exists", { path, options });
+  return await invoke("plugin:fs|exists", { path, options });
 }
 
 async function metadata(path) {
-  return await window.__TAURI_INVOKE__("plugin:fs|metadata", {
+  return await invoke("plugin:fs|metadata", {
     path,
   });
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,570 @@
+//! Access the file system.
+//!
+//! # Security
+//!
+//! This module prevents path traversal, not allowing absolute paths or parent dir components
+//! (i.e. "/usr/path/to/file" or "../path/to/file" paths are not allowed).
+//! Paths accessed with this API must be relative to one of the {@link BaseDirectory | base directories}
+//! so if you need access to arbitrary filesystem paths, you must write such logic on the core layer instead.
+//!
+//! The API has a scope configuration that forces you to restrict the paths that can be accessed using glob patterns.
+//!
+//! The scope configuration is an array of glob patterns describing folder paths that are allowed.
+//! For instance, this scope configuration only allows accessing files on the
+//! *databases* folder of the {@link path.appDataDir | $APPDATA directory}:
+//! ```json
+//! {
+//!   "plugins": {
+//!     "fs": {
+//!       "scope": ["$APPDATA/databases/*"]
+//!     }
+//!   }
+//! }
+//! ```
+//!
+//! Notice the use of the `$APPDATA` variable. The value is injected at runtime, resolving to the {@link path.appDataDir | app data directory}.
+//! The available variables are:
+//! {@link path.appConfigDir | `$APPCONFIG`}, {@link path.appDataDir | `$APPDATA`}, {@link path.appLocalDataDir | `$APPLOCALDATA`},
+//! {@link path.appCacheDir | `$APPCACHE`}, {@link path.appLogDir | `$APPLOG`},
+//! {@link path.audioDir | `$AUDIO`}, {@link path.cacheDir | `$CACHE`}, {@link path.configDir | `$CONFIG`}, {@link path.dataDir | `$DATA`},
+//! {@link path.localDataDir | `$LOCALDATA`}, {@link path.desktopDir | `$DESKTOP`}, {@link path.documentDir | `$DOCUMENT`},
+//! {@link path.downloadDir | `$DOWNLOAD`}, {@link path.executableDir | `$EXE`}, {@link path.fontDir | `$FONT`}, {@link path.homeDir | `$HOME`},
+//! {@link path.pictureDir | `$PICTURE`}, {@link path.publicDir | `$PUBLIC`}, {@link path.runtimeDir | `$RUNTIME`},
+//! {@link path.templateDir | `$TEMPLATE`}, {@link path.videoDir | `$VIDEO`}, {@link path.resourceDir | `$RESOURCE`},
+//! {@link os.tempdir | `$TEMP`}.
+//!
+//! Trying to execute any API with a URL not configured on the scope results in a promise rejection due to denied access.
+//!
+//! Note that this scope applies to **all** APIs on this module.
+use crate::Error;
+use js_sys::{ArrayBuffer, Uint8Array};
+use serde::{Deserialize, Serialize};
+use serde_repr::*;
+use std::path::{Path, PathBuf};
+use std::str;
+
+#[derive(Serialize_repr, Clone, PartialEq, Eq, Debug)]
+#[repr(u16)]
+pub enum BaseDirectory {
+    Audio = 1,
+    Cache = 2,
+    Config = 3,
+    Data = 4,
+    LocalData = 5,
+    Document = 6,
+    Download = 7,
+    Picture = 8,
+    Public = 9,
+    Video = 10,
+    Resource = 11,
+    Temp = 12,
+    AppConfig = 13,
+    AppData = 14,
+    AppLocalData = 15,
+    AppCache = 16,
+    AppLog = 17,
+    Desktop = 18,
+    Executable = 19,
+    Font = 20,
+    Home = 21,
+    Runtime = 22,
+    Template = 23,
+}
+
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+pub struct FileEntry {
+    pub path: PathBuf,
+    pub name: Option<String>,
+    pub children: Option<Vec<FileEntry>>,
+}
+
+#[derive(Serialize, Clone, PartialEq, Debug)]
+struct FsDirOptions {
+    pub dir: Option<BaseDirectory>,
+    pub recursive: Option<bool>,
+}
+
+#[derive(Serialize, Clone, PartialEq, Debug)]
+struct FsOptions {
+    pub dir: Option<BaseDirectory>,
+}
+
+#[derive(Serialize, Clone, PartialEq, Debug)]
+struct FsTextFileOption {
+    pub contents: String,
+    path: PathBuf,
+}
+
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+pub struct Permissions {
+    /// Indicates if these permissions describe a readonly (unwritable) file
+    readonly: bool,
+    /// The underlying raw `st_mode` bits that contain the standard Unix permissions for this file.
+    mode: Option<usize>,
+}
+
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Metadata {
+    #[serde(rename = "accessedAtMs")]
+    /// The last access time of this metadata.
+    pub accessed_at: i64,
+    #[serde(rename = "createdAtMs")]
+    /// The creation time listed in this metadata.    
+    pub created_at: i64,
+    #[serde(rename = "modifiedAtMs")]
+    /// The last modification time listed in this metadata.
+    pub modified_at: i64,
+    /// Indicates if this metadata is for a directory.
+    pub is_dir: bool,
+    /// Indicates if this metadata is for a regular file.
+    pub is_file: bool,
+    /// Indicates if this metadata is for a symbolic link.
+    pub is_symlink: bool,
+    /// The size of the file, in bytes, this metadata is for.
+    pub size: u64,
+    /// The permissions of the file this metadata is for.
+    pub permissions: Permissions,
+    /// The ID of the device containing the file. Only available on Unix.
+    pub dev: Option<u64>,
+    /// The inode number. Only available on Unix.
+    pub ino: Option<u64>,
+    /// The rights applied to this file. Only available on Unix.
+    pub mode: Option<u32>,
+    /// The number of hard links pointing to this file. Only available on Unix.
+    pub nlink: Option<u64>,
+    /// The user ID of the owner of this file. Only available on Unix.
+    pub uid: Option<u32>,
+    /// The group ID of the owner of this file. Only available on Unix.
+    pub gid: Option<u32>,
+    /// The device ID of this file (if it is a special one). Only available on Unix.
+    pub rdev: Option<u64>,
+    /// The block size for filesystem I/O. Only available on Unix.
+    pub blksize: Option<u64>,
+    /// The number of blocks allocated to the file, in 512-byte units. Only available on Unix.
+    pub blocks: Option<u64>,
+}
+
+/// Copies a file to a destination.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::copy_file(source, destination, BaseDirectory::Download).expect("could not copy file");
+/// ```
+pub async fn copy_file(source: &Path, destination: &Path, dir: BaseDirectory) -> crate::Result<()> {
+    let Some(source) = source.to_str() else {
+        return Err(Error::Utf8(source.to_path_buf()));
+    };
+
+    let Some(destination) = destination.to_str() else {
+        return Err(Error::Utf8(destination.to_path_buf()));
+    };
+
+    let raw = inner::copyFile(
+        source,
+        destination,
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// Creates a directory.
+/// If one of the path's parent components doesn't exist the promise will be rejected.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::create_dir(dir, BaseDirectory::Download).expect("could not create directory");
+/// ```
+pub async fn create_dir(dir: &Path, base_dir: BaseDirectory) -> crate::Result<()> {
+    let recursive = Some(false);
+
+    let Some(dir) = dir.to_str() else {
+        return Err(Error::Utf8(dir.to_path_buf()));
+    };
+
+    Ok(inner::createDir(
+        dir,
+        serde_wasm_bindgen::to_value(&FsDirOptions {
+            dir: Some(base_dir),
+            recursive,
+        })?,
+    )
+    .await?)
+}
+
+/// Creates a directory recursively.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::create_dir_all(dir, BaseDirectory::Download).expect("could not create directory");
+/// ```
+pub async fn create_dir_all(dir: &Path, base_dir: BaseDirectory) -> crate::Result<()> {
+    let recursive = Some(true);
+
+    let Some(dir) = dir.to_str() else {
+        return Err(Error::Utf8(dir.to_path_buf()));
+    };
+
+    Ok(inner::createDir(
+        dir,
+        serde_wasm_bindgen::to_value(&FsDirOptions {
+            dir: Some(base_dir),
+            recursive,
+        })?,
+    )
+    .await?)
+}
+
+/// Checks if a path exists.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// let file_exists = fs::exists(path, BaseDirectory::Download).expect("could not check if path exists");
+/// ```
+pub async fn exists(path: &Path, dir: BaseDirectory) -> crate::Result<bool> {
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    let raw = inner::exists(
+        path,
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// Reads a file as a byte array.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// let contents = fs::read_binary_file(filePath, BaseDirectory::Download).expect("could not read file contents");
+/// ```
+pub async fn read_binary_file(path: &Path, dir: BaseDirectory) -> crate::Result<Vec<u8>> {
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    let raw = inner::readBinaryFile(
+        path,
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// List directory files.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// let files = fs::read_dir(path, BaseDirectory::Download).expect("could not read directory");
+/// ```
+pub async fn read_dir(path: &Path, dir: BaseDirectory) -> crate::Result<Vec<FileEntry>> {
+    let recursive = Some(false);
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    let raw = inner::readDir(
+        path,
+        serde_wasm_bindgen::to_value(&FsDirOptions {
+            dir: Some(dir),
+            recursive,
+        })?,
+    )
+    .await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// List directory files recursively.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// let files = fs::read_dir_all(path, BaseDirectory::Download).expect("could not read directory");
+/// ```
+pub async fn read_dir_all(path: &Path, dir: BaseDirectory) -> crate::Result<Vec<FileEntry>> {
+    let recursive = Some(true);
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    let raw = inner::readDir(
+        path,
+        serde_wasm_bindgen::to_value(&FsDirOptions {
+            dir: Some(dir),
+            recursive,
+        })?,
+    )
+    .await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// Read a file as an UTF-8 encoded string.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// let contents = fs::readTextFile(path, BaseDirectory::Download).expect("could not read file as text");
+/// ```
+pub async fn read_text_file(path: &Path, dir: BaseDirectory) -> crate::Result<String> {
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    let raw = inner::readTextFile(
+        path,
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// Removes a directory.
+/// If the directory is not empty the promise will be rejected.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::remove_dir(path, BaseDirectory::Download).expect("could not remove directory");
+/// ```
+pub async fn remove_dir(dir: &Path, base_dir: BaseDirectory) -> crate::Result<()> {
+    let recursive = Some(false);
+    let Some(dir) = dir.to_str() else {
+        return Err(Error::Utf8(dir.to_path_buf()));
+    };
+
+    Ok(inner::removeDir(
+        dir,
+        serde_wasm_bindgen::to_value(&FsDirOptions {
+            dir: Some(base_dir),
+            recursive,
+        })?,
+    )
+    .await?)
+}
+
+/// Removes a directory and its contents.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::remove_dir_all(path, BaseDirectory::Download).expect("could not remove directory");
+/// ```
+pub async fn remove_dir_all(dir: &Path, base_dir: BaseDirectory) -> crate::Result<()> {
+    let recursive = Some(true);
+    let Some(dir) = dir.to_str() else {
+        return Err(Error::Utf8(dir.to_path_buf()));
+    };
+
+    Ok(inner::removeDir(
+        dir,
+        serde_wasm_bindgen::to_value(&FsDirOptions {
+            dir: Some(base_dir),
+            recursive,
+        })?,
+    )
+    .await?)
+}
+
+/// Removes a file.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::remove_file(path, BaseDirectory::Download).expect("could not remove file");
+/// ```
+pub async fn remove_file(file: &Path, dir: BaseDirectory) -> crate::Result<()> {
+    let Some(file) = file.to_str() else {
+        return Err(Error::Utf8(file.to_path_buf()));
+    };
+
+    Ok(inner::removeFile(
+        file,
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?)
+}
+
+/// Renames a file.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::rename_file(old_path, new_path, BaseDirectory::Download).expect("could not rename file");
+/// ```
+pub async fn rename_file(
+    old_path: &Path,
+    new_path: &Path,
+    dir: BaseDirectory,
+) -> crate::Result<()> {
+    let Some(old_path) = old_path.to_str() else {
+        return Err(Error::Utf8(old_path.to_path_buf()));
+    };
+
+    let Some(new_path) = new_path.to_str() else {
+        return Err(Error::Utf8(new_path.to_path_buf()));
+    };
+
+    Ok(inner::renameFile(
+        old_path,
+        new_path,
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?)
+}
+
+/// Writes a byte array content to a file.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::write_binary_file(path, contents, BaseDirectory::Download).expect("could not writet binary file");
+/// ```
+pub async fn write_binary_file(
+    path: &Path,
+    contents: &Vec<u8>,
+    dir: BaseDirectory,
+) -> crate::Result<()> {
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    let array = Uint8Array::from(contents.as_slice());
+
+    Ok(inner::writeBinaryFile(
+        path,
+        array.buffer(),
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?)
+}
+
+/// Writes a UTF-8 text file.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::write_text_file(path, contents, BaseDirectory::Download).expect("could not writet binary file");
+/// ```
+pub async fn write_text_file(path: &Path, contents: &str, dir: BaseDirectory) -> crate::Result<()> {
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    Ok(inner::writeTextFile(
+        path,
+        &contents,
+        serde_wasm_bindgen::to_value(&FsOptions { dir: Some(dir) })?,
+    )
+    .await?)
+}
+
+/// Returns the metadata for the given path.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tauri_sys::fs;
+///
+/// fs::metadata(path).expect("failed to get metadata");
+/// ```
+pub async fn metadata(path: &Path) -> crate::Result<Metadata> {
+    let Some(path) = path.to_str() else {
+        return Err(Error::Utf8(path.to_path_buf()));
+    };
+
+    let raw = inner::metadata(path).await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+mod inner {
+    use super::ArrayBuffer;
+    use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
+
+    #[wasm_bindgen(module = "/src/fs.js")]
+    extern "C" {
+        #[wasm_bindgen(catch)]
+        pub async fn copyFile(
+            source: &str,
+            destination: &str,
+            options: JsValue,
+        ) -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn createDir(dir: &str, options: JsValue) -> Result<(), JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn exists(path: &str, options: JsValue) -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn readBinaryFile(filePath: &str, options: JsValue) -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn readTextFile(filePath: &str, options: JsValue) -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn readDir(dir: &str, options: JsValue) -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn removeDir(dir: &str, options: JsValue) -> Result<(), JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn removeFile(source: &str, options: JsValue) -> Result<(), JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn renameFile(
+            oldPath: &str,
+            newPath: &str,
+            options: JsValue,
+        ) -> Result<(), JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn writeBinaryFile(
+            filePath: &str,
+            contents: ArrayBuffer,
+            options: JsValue,
+        ) -> Result<(), JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn writeTextFile(
+            filePath: &str,
+            contents: &str,
+            options: JsValue,
+        ) -> Result<(), JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn metadata(path: &str) -> Result<JsValue, JsValue>;
+    }
+}

--- a/src/globalShortcut.js
+++ b/src/globalShortcut.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke, transformCallback } = window.__TAURI__.primitives;
 
 class Channel {
   id;
@@ -6,7 +6,7 @@ class Channel {
   #onmessage = () => {};
 
   constructor() {
-    this.id = window.__TAURI__.transformCallback((response) => {
+    this.id = transformCallback((response) => {
       this.#onmessage(response);
     });
   }

--- a/src/globalShortcut.js
+++ b/src/globalShortcut.js
@@ -1,3 +1,5 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 class Channel {
   id;
   __TAURI_CHANNEL_MARKER__ = true;
@@ -26,7 +28,7 @@ async function register(shortcut, handler) {
   const h = new Channel();
   h.onmessage = handler;
 
-  return window.__TAURI_INVOKE__("plugin:globalShortcut|register", {
+  return invoke("plugin:globalShortcut|register", {
     shortcut,
     handler: h,
   });
@@ -36,26 +38,26 @@ async function registerAll(shortcuts, handler) {
   const h = new Channel();
   h.onmessage = handler;
 
-  return window.__TAURI_INVOKE__("plugin:globalShortcut|register_all", {
+  return invoke("plugin:globalShortcut|register_all", {
     shortcuts,
     handler: h,
   });
 }
 
 async function isRegistered(shortcut) {
-  return window.__TAURI_INVOKE__("plugin:globalShortcut|is_registered", {
+  return invoke("plugin:globalShortcut|is_registered", {
     shortcut,
   });
 }
 
 async function unregister(shortcut) {
-  return window.__TAURI_INVOKE__("plugin:globalShortcut|unregister", {
+  return invoke("plugin:globalShortcut|unregister", {
     shortcut,
   });
 }
 
 async function unregisterAll() {
-  return window.__TAURI_INVOKE__("plugin:globalShortcut|unregister_all");
+  return invoke("plugin:globalShortcut|unregister_all");
 }
 
 export { register, registerAll, isRegistered, unregister, unregisterAll };

--- a/src/globalShortcut.js
+++ b/src/globalShortcut.js
@@ -29,9 +29,6 @@ async function register(shortcut, handler) {
   return window.__TAURI_INVOKE__("plugin:globalShortcut|register", {
     shortcut,
     handler: h,
-  }).then(() => {
-    console.log('return unregister');
-    return async () => unregister(shortcut);
   });
 }
 

--- a/src/global_shortcut.rs
+++ b/src/global_shortcut.rs
@@ -23,20 +23,6 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
-//! The APIs must be added to tauri.allowlist.globalShortcut in tauri.conf.json:
-//!
-//! ```json
-//! {
-//!     "tauri": {
-//!         "allowlist": {
-//!             "globalShortcut": {
-//!                 "all": true // enable all global shortcut APIs
-//!             }
-//!         }
-//!     }
-//! }
-//! ```
 //! It is recommended to allowlist only the APIs you use for optimal bundle size and security.
 
 use futures::{channel::mpsc, Stream, StreamExt};

--- a/src/global_shortcut.rs
+++ b/src/global_shortcut.rs
@@ -63,7 +63,6 @@ pub async fn is_registered(shortcut: &str) -> crate::Result<bool> {
 /// Register a global shortcut.
 ///
 /// The returned Future will automatically clean up it's underlying event listener when dropped, so no manual unlisten function needs to be called.
-/// See [Differences to the JavaScript API](../index.html#differences-to-the-javascript-api) for details.
 ///
 /// # Examples
 ///
@@ -72,9 +71,9 @@ pub async fn is_registered(shortcut: &str) -> crate::Result<bool> {
 /// use web_sys::console;
 ///
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let events = register("CommandOrControl+Shift+C").await?;
+/// let mut events = register("CommandOrControl+Shift+C").await?;
 ///
-/// while let Some(_) in events.next().await {
+/// while let Some(_) = events.next().await {
 ///     console::log_1(&"Shortcut triggered".into());
 /// }
 /// # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@ pub mod notification;
 pub mod os;
 #[cfg(feature = "path")]
 pub mod path;
+#[cfg(feature = "positioner")]
+pub mod positioner;
 #[cfg(feature = "process")]
 pub mod process;
 #[cfg(feature = "tauri")]
@@ -155,24 +157,24 @@ pub(crate) mod utils {
         pos: u32,
         arr: js_sys::Array,
     }
-    
+
     impl ArrayIterator {
         pub fn new(arr: js_sys::Array) -> Self {
             Self { pos: 0, arr }
         }
     }
-    
+
     impl Iterator for ArrayIterator {
         type Item = wasm_bindgen::JsValue;
-    
+
         fn next(&mut self) -> Option<Self::Item> {
             let raw = self.arr.get(self.pos);
-    
+
             if raw.is_undefined() {
                 None
             } else {
                 self.pos += 1;
-    
+
                 Some(raw)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,8 @@ pub mod path;
 pub mod positioner;
 #[cfg(feature = "process")]
 pub mod process;
+#[cfg(feature = "store")]
+pub mod store;
 #[cfg(feature = "tauri")]
 pub mod tauri;
 #[cfg(feature = "updater")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,8 @@ pub mod dialog;
 mod error;
 #[cfg(feature = "event")]
 pub mod event;
+#[cfg(feature = "fs")]
+pub mod fs;
 #[cfg(feature = "global_shortcut")]
 pub mod global_shortcut;
 #[cfg(feature = "mocks")]

--- a/src/notification.js
+++ b/src/notification.js
@@ -1,61 +1,14 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/notification.ts
 async function isPermissionGranted() {
   if (window.Notification.permission !== "default") {
     return Promise.resolve(window.Notification.permission === "granted");
   }
-  return invokeTauriCommand({
-    __tauriModule: "Notification",
-    message: {
-      cmd: "isNotificationPermissionGranted"
-    }
-  });
+  return window.___TAURI_INVOKE__("plugin:notification|is_permission_granted");
 }
+
 async function requestPermission() {
   return window.Notification.requestPermission();
 }
+
 function sendNotification(options) {
   if (typeof options === "string") {
     new window.Notification(options);
@@ -63,8 +16,5 @@ function sendNotification(options) {
     new window.Notification(options.title, options);
   }
 }
-export {
-  isPermissionGranted,
-  requestPermission,
-  sendNotification
-};
+
+export { sendNotification, requestPermission, isPermissionGranted };

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,7 +1,7 @@
 //! Send toast notifications (brief auto-expiring OS window element) to your user. Can also be used with the Notification Web API.
-//! 
+//!
 //! The APIs must be added to tauri.allowlist.notification in tauri.conf.json:
-//! 
+//!
 //! ```json
 //! {
 //!     "tauri": {
@@ -83,18 +83,21 @@ impl<'a> Notification<'a> {
     }
 
     /// Sets the notification title.
-    pub fn set_title(&mut self, title: &'a str) {
+    pub fn set_title(&mut self, title: &'a str) -> &mut Self {
         self.title = Some(title);
+        self
     }
 
     /// Sets the notification body.
-    pub fn set_body(&mut self, body: &'a str) {
+    pub fn set_body(&mut self, body: &'a str) -> &mut Self {
         self.body = Some(body);
+        self
     }
 
     /// Sets the notification icon.
-    pub fn set_icon(&mut self, icon: &'a str) {
+    pub fn set_icon(&mut self, icon: &'a str) -> &mut Self {
         self.icon = Some(icon);
+        self
     }
 
     /// Shows the notification.

--- a/src/os.js
+++ b/src/os.js
@@ -1,98 +1,37 @@
-// tauri/tooling/api/src/helpers/os-check.ts
-function isWindows() {
-  return navigator.appVersion.includes("Win");
+function eol() {
+  return window.__TAURI__.os.__eol;
 }
 
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/os.ts
-var EOL = isWindows() ? "\r\n" : "\n";
 async function platform() {
-  return invokeTauriCommand({
-    __tauriModule: "Os",
-    message: {
-      cmd: "platform"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:os|platform");
 }
+
 async function version() {
-  return invokeTauriCommand({
-    __tauriModule: "Os",
-    message: {
-      cmd: "version"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:os|version");
 }
+
+async function family() {
+  return window.__TAURI_INVOKE__("plugin:os|family");
+}
+
 async function type() {
-  return invokeTauriCommand({
-    __tauriModule: "Os",
-    message: {
-      cmd: "osType"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:os|os_type");
 }
+
 async function arch() {
-  return invokeTauriCommand({
-    __tauriModule: "Os",
-    message: {
-      cmd: "arch"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:os|arch");
 }
-async function tempdir() {
-  return invokeTauriCommand({
-    __tauriModule: "Os",
-    message: {
-      cmd: "tempdir"
-    }
-  });
+
+async function locale() {
+  return window.__TAURI_INVOKE__("plugin:os|locale");
 }
-export {
-  EOL,
-  arch,
-  platform,
-  tempdir,
-  type,
-  version
-};
+
+async function exeExtension() {
+  return window.__TAURI_INVOKE__("plugin:os|exe_extension");
+}
+
+async function hostname() {
+  return window.__TAURI_INVOKE__("plugin:os|hostname");
+}
+
+export { eol, platform, family, version, type, arch, locale, exeExtension, hostname };

--- a/src/os.js
+++ b/src/os.js
@@ -1,37 +1,39 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 function eol() {
   return window.__TAURI__.os.__eol;
 }
 
 async function platform() {
-  return window.__TAURI_INVOKE__("plugin:os|platform");
+  return invoke("plugin:os|platform");
 }
 
 async function version() {
-  return window.__TAURI_INVOKE__("plugin:os|version");
+  return invoke("plugin:os|version");
 }
 
 async function family() {
-  return window.__TAURI_INVOKE__("plugin:os|family");
+  return invoke("plugin:os|family");
 }
 
 async function type() {
-  return window.__TAURI_INVOKE__("plugin:os|os_type");
+  return invoke("plugin:os|os_type");
 }
 
 async function arch() {
-  return window.__TAURI_INVOKE__("plugin:os|arch");
+  return invoke("plugin:os|arch");
 }
 
 async function locale() {
-  return window.__TAURI_INVOKE__("plugin:os|locale");
+  return invoke("plugin:os|locale");
 }
 
 async function exeExtension() {
-  return window.__TAURI_INVOKE__("plugin:os|exe_extension");
+  return invoke("plugin:os|exe_extension");
 }
 
 async function hostname() {
-  return window.__TAURI_INVOKE__("plugin:os|hostname");
+  return invoke("plugin:os|hostname");
 }
 
 export { eol, platform, family, version, type, arch, locale, exeExtension, hostname };

--- a/src/os.rs
+++ b/src/os.rs
@@ -1,5 +1,5 @@
 //! Provides operating system-related utility methods and properties.
-//! 
+//!
 //! The APIs must be added to tauri.allowlist.os in tauri.conf.json:
 //! ```json
 //! {
@@ -47,8 +47,8 @@ pub enum Arch {
 pub enum Platform {
     #[serde(rename = "linux")]
     Linux,
-    #[serde(rename = "darwin")]
-    Darwin,
+    #[serde(rename = "macos")]
+    Macos,
     #[serde(rename = "ios")]
     Ios,
     #[serde(rename = "freebsd")]
@@ -63,18 +63,30 @@ pub enum Platform {
     Solaris,
     #[serde(rename = "android")]
     Android,
-    #[serde(rename = "win32")]
-    Win32,
+    #[serde(rename = "windows")]
+    Windows,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OsKind {
-    #[serde(rename = "Linux")]
+    #[serde(rename = "linux")]
     Linux,
-    #[serde(rename = "Darwin")]
-    Darwin,
-    #[serde(rename = "Windows_NT")]
-    WindowsNT,
+    #[serde(rename = "macos")]
+    Macos,
+    #[serde(rename = "windows")]
+    Windows,
+    #[serde(rename = "ios")]
+    Ios,
+    #[serde(rename = "android")]
+    Android,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Family {
+    #[serde(rename = "unix")]
+    Unix,
+    #[serde(rename = "windows")]
+    Windows,
 }
 
 /// Returns the operating system CPU architecture for which the tauri app was compiled.
@@ -93,10 +105,10 @@ pub async fn platform() -> crate::Result<Platform> {
     Ok(serde_wasm_bindgen::from_value(raw)?)
 }
 
-/// Returns the operating system's default directory for temporary files.
+/// Returns the operating system's family.
 #[inline(always)]
-pub async fn tempdir() -> crate::Result<PathBuf> {
-    let raw = inner::tempdir().await?;
+pub async fn family() -> crate::Result<PathBuf> {
+    let raw = inner::family().await?;
 
     Ok(serde_wasm_bindgen::from_value(raw)?)
 }
@@ -117,6 +129,30 @@ pub async fn version() -> crate::Result<String> {
     Ok(serde_wasm_bindgen::from_value(raw)?)
 }
 
+/// Returns the system's locale.
+#[inline(always)]
+pub async fn locale() -> crate::Result<String> {
+    let raw = inner::locale().await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// Returns the executable extension.
+#[inline(always)]
+pub async fn executable_ext() -> crate::Result<String> {
+    let raw = inner::executable_ext().await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
+/// Returns the hostname.
+#[inline(always)]
+pub async fn hostname() -> crate::Result<String> {
+    let raw = inner::hostname().await?;
+
+    Ok(serde_wasm_bindgen::from_value(raw)?)
+}
+
 mod inner {
     use wasm_bindgen::prelude::*;
 
@@ -127,10 +163,16 @@ mod inner {
         #[wasm_bindgen(catch)]
         pub async fn platform() -> Result<JsValue, JsValue>;
         #[wasm_bindgen(catch)]
-        pub async fn tempdir() -> Result<JsValue, JsValue>;
+        pub async fn family() -> Result<JsValue, JsValue>;
         #[wasm_bindgen(catch, js_name = "type")]
         pub async fn kind() -> Result<JsValue, JsValue>;
         #[wasm_bindgen(catch)]
         pub async fn version() -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn locale() -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch, js_name = "exeExtension")]
+        pub async fn executable_ext() -> Result<JsValue, JsValue>;
+        #[wasm_bindgen(catch)]
+        pub async fn hostname() -> Result<JsValue, JsValue>;
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,18 +1,4 @@
 //! The path module provides utilities for working with file and directory paths.
-//! 
-//! The APIs must be added to tauri.allowlist.path in tauri.conf.json:
-//! ```json
-//! {
-//!     "tauri": {
-//!         "allowlist": {
-//!             "path": {
-//!                 "all": true, // enable all Path APIs
-//!             }
-//!         }
-//!     }
-//! }
-//! ```
-//! It is recommended to allowlist only the APIs you use for optimal bundle size and security.
 
 use std::path::PathBuf;
 use wasm_bindgen::JsValue;

--- a/src/positioner.js
+++ b/src/positioner.js
@@ -1,0 +1,7 @@
+async function moveWindow(to) {
+  await window.__TAURI_INVOKE__("plugin:positioner|move_window", {
+    position: parseInt(to),
+  });
+}
+
+export { moveWindow };

--- a/src/positioner.js
+++ b/src/positioner.js
@@ -1,5 +1,7 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function moveWindow(to) {
-  await window.__TAURI_INVOKE__("plugin:positioner|move_window", {
+  await invoke("plugin:positioner|move_window", {
     position: parseInt(to),
   });
 }

--- a/src/positioner.rs
+++ b/src/positioner.rs
@@ -1,0 +1,56 @@
+//! A plugin for Tauri that helps position your windows at well-known locations.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Position {
+    #[serde(rename = "0")]
+    TopLeft,
+    #[serde(rename = "1")]
+    TopRight,
+    #[serde(rename = "2")]
+    BottomLeft,
+    #[serde(rename = "3")]
+    BottomRight,
+    #[serde(rename = "4")]
+    TopCenter,
+    #[serde(rename = "5")]
+    BottomCenter,
+    #[serde(rename = "6")]
+    LeftCenter,
+    #[serde(rename = "7")]
+    RightCenter,
+    #[serde(rename = "8")]
+    Center,
+    #[serde(rename = "9")]
+    TrayLeft,
+    #[serde(rename = "10")]
+    TrayBottomLeft,
+    #[serde(rename = "11")]
+    TrayRight,
+    #[serde(rename = "12")]
+    TrayBottomRight,
+    #[serde(rename = "13")]
+    TrayCenter,
+    #[serde(rename = "14")]
+    TrayBottomCenter,
+}
+
+/// Moves the `Window` to the given position using `WindowExt.move_window()`
+/// * All positions are relative to the **current** screen.
+#[inline(always)]
+pub async fn move_window(position: Position) -> crate::Result<()> {
+    inner::move_window(serde_wasm_bindgen::to_value(&position)?).await?;
+
+    Ok(())
+}
+
+mod inner {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen(module = "/src/positioner.js")]
+    extern "C" {
+        #[wasm_bindgen(catch, js_name = "moveWindow")]
+        pub async fn move_window(position: JsValue) -> Result<(), JsValue>;
+    }
+}

--- a/src/process.js
+++ b/src/process.js
@@ -1,65 +1,9 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
+async function exit(code = 0) {
+  return window.__TAURI_INVOKE__("plugin:process|exit", { code });
 }
 
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/process.ts
-async function exit(exitCode = 0) {
-  return invokeTauriCommand({
-    __tauriModule: "Process",
-    message: {
-      cmd: "exit",
-      exitCode
-    }
-  });
-}
 async function relaunch() {
-  return invokeTauriCommand({
-    __tauriModule: "Process",
-    message: {
-      cmd: "relaunch"
-    }
-  });
+  return window.__TAURI_INVOKE__("plugin:process|restart");
 }
-export {
-  exit,
-  relaunch
-};
+
+export { exit, relaunch };

--- a/src/process.js
+++ b/src/process.js
@@ -1,9 +1,11 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function exit(code = 0) {
-  return window.__TAURI_INVOKE__("plugin:process|exit", { code });
+  return invoke("plugin:process|exit", { code });
 }
 
 async function relaunch() {
-  return window.__TAURI_INVOKE__("plugin:process|restart");
+  return invoke("plugin:process|restart");
 }
 
 export { exit, relaunch };

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,121 @@
+async function _unlisten(event, eventId) {
+  await window.__TAURI_INVOKE__("plugin:event|unlisten", {
+    event,
+    eventId,
+  });
+}
+
+async function listen(event, handler, options) {
+  return window
+    .__TAURI_INVOKE__("plugin:event|listen", {
+      event,
+      windowLabel: options?.target,
+      handler: window.__TAURI__.transformCallback(handler),
+    })
+    .then((eventId) => {
+      return async () => _unlisten(event, eventId);
+    });
+}
+
+export class Store {
+  path;
+
+  constructor(path) {
+    this.path = path;
+  }
+
+  async set(key, value) {
+    return await window.__TAURI_INVOKE__("plugin:store|set", {
+      path: this.path,
+      key,
+      value,
+    });
+  }
+
+  async get(key) {
+    return await window.__TAURI_INVOKE__("plugin:store|get", {
+      path: this.path,
+      key,
+    });
+  }
+
+  async has(key) {
+    return await window.__TAURI_INVOKE__("plugin:store|has", {
+      path: this.path,
+      key,
+    });
+  }
+
+  async delete(key) {
+    return await window.__TAURI_INVOKE__("plugin:store|delete", {
+      path: this.path,
+      key,
+    });
+  }
+
+  async clear() {
+    return await window.__TAURI_INVOKE__("plugin:store|clear", {
+      path: this.path,
+    });
+  }
+
+  async reset() {
+    return await window.__TAURI_INVOKE__("plugin:store|reset", {
+      path: this.path,
+    });
+  }
+
+  async keys() {
+    return await window.__TAURI_INVOKE__("plugin:store|keys", {
+      path: this.path,
+    });
+  }
+
+  async values() {
+    return await window.__TAURI_INVOKE__("plugin:store|values", {
+      path: this.path,
+    });
+  }
+
+  async entries() {
+    console.log("path", this.path);
+    return await window.__TAURI_INVOKE__("plugin:store|entries", {
+      path: this.path,
+    });
+  }
+
+  async length() {
+    console.log("path", this.path);
+    return await window.__TAURI_INVOKE__("plugin:store|length", {
+      path: this.path,
+    });
+  }
+
+  async load() {
+    return await window.__TAURI_INVOKE__("plugin:store|load", {
+      path: this.path,
+    });
+  }
+
+  async save() {
+    return await window.__TAURI_INVOKE__("plugin:store|save", {
+      path: this.path,
+    });
+  }
+
+  async onKeyChange(key, cb) {
+    return (await listen)("store://change", (event) => {
+      if (event.payload.path === this.path && event.payload.key === key) {
+        cb(event.payload.value);
+      }
+    });
+  }
+
+  async onChange(cb) {
+    return (await listen)("store://change", (event) => {
+      if (event.payload.path === this.path) {
+        cb(event.payload.key, event.payload.value);
+      }
+    });
+  }
+}

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,7 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 async function _unlisten(event, eventId) {
-  await window.__TAURI_INVOKE__("plugin:event|unlisten", {
+  await invoke("plugin:event|unlisten", {
     event,
     eventId,
   });
@@ -25,7 +27,7 @@ export class Store {
   }
 
   async set(key, value) {
-    return await window.__TAURI_INVOKE__("plugin:store|set", {
+    return await invoke("plugin:store|set", {
       path: this.path,
       key,
       value,
@@ -33,72 +35,72 @@ export class Store {
   }
 
   async get(key) {
-    return await window.__TAURI_INVOKE__("plugin:store|get", {
+    return await invoke("plugin:store|get", {
       path: this.path,
       key,
     });
   }
 
   async has(key) {
-    return await window.__TAURI_INVOKE__("plugin:store|has", {
+    return await invoke("plugin:store|has", {
       path: this.path,
       key,
     });
   }
 
   async delete(key) {
-    return await window.__TAURI_INVOKE__("plugin:store|delete", {
+    return await invoke("plugin:store|delete", {
       path: this.path,
       key,
     });
   }
 
   async clear() {
-    return await window.__TAURI_INVOKE__("plugin:store|clear", {
+    return await invoke("plugin:store|clear", {
       path: this.path,
     });
   }
 
   async reset() {
-    return await window.__TAURI_INVOKE__("plugin:store|reset", {
+    return await invoke("plugin:store|reset", {
       path: this.path,
     });
   }
 
   async keys() {
-    return await window.__TAURI_INVOKE__("plugin:store|keys", {
+    return await invoke("plugin:store|keys", {
       path: this.path,
     });
   }
 
   async values() {
-    return await window.__TAURI_INVOKE__("plugin:store|values", {
+    return await invoke("plugin:store|values", {
       path: this.path,
     });
   }
 
   async entries() {
     console.log("path", this.path);
-    return await window.__TAURI_INVOKE__("plugin:store|entries", {
+    return await invoke("plugin:store|entries", {
       path: this.path,
     });
   }
 
   async length() {
     console.log("path", this.path);
-    return await window.__TAURI_INVOKE__("plugin:store|length", {
+    return await invoke("plugin:store|length", {
       path: this.path,
     });
   }
 
   async load() {
-    return await window.__TAURI_INVOKE__("plugin:store|load", {
+    return await invoke("plugin:store|load", {
       path: this.path,
     });
   }
 
   async save() {
-    return await window.__TAURI_INVOKE__("plugin:store|save", {
+    return await invoke("plugin:store|save", {
       path: this.path,
     });
   }

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke, transformCallback } = window.__TAURI__.primitives;
 
 async function _unlisten(event, eventId) {
   await invoke("plugin:event|unlisten", {
@@ -12,7 +12,7 @@ async function listen(event, handler, options) {
     .__TAURI_INVOKE__("plugin:event|listen", {
       event,
       windowLabel: options?.target,
-      handler: window.__TAURI__.transformCallback(handler),
+      handler: transformCallback(handler),
     })
     .then((eventId) => {
       return async () => _unlisten(event, eventId);

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,284 @@
+//! Simple, persistent key-value store.
+
+use crate::event::Listen;
+use futures::{channel::mpsc, Stream};
+use serde::{de::DeserializeOwned, Serialize};
+use std::path::PathBuf;
+use wasm_bindgen::{prelude::Closure, JsValue};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct KeyValuePair<T> {
+    key: String,
+    value: T,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Store(inner::Store);
+
+impl Store {
+    pub fn new(path: &PathBuf) -> Self {
+        Self(inner::Store::new(path.to_str().unwrap()))
+    }
+
+    /// Inserts a key-value pair into the store.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tauri_api::store::Store;
+    ///
+    /// let store = Store::new("/home/user/.local/app/settings.dat");
+    ///
+    /// store.set("dark_mode", true).await;
+    /// ```
+    pub async fn set<T: Serialize>(self, key: &str, value: T) -> crate::Result<()> {
+        let serialized_value = serde_wasm_bindgen::to_value(&value)?;
+
+        self.0.set(key, serialized_value).await?;
+
+        Ok(())
+    }
+
+    /// Returns the value for the given `key` or None if the key does not exist.
+    ///
+    /// ```rust,no_run
+    /// use tauri_api::store::Store;
+    ///
+    /// let store = Store::new("/home/user/.local/app/settings.dat");
+    ///
+    /// let is_dark_mode = store.get("dark_mode").await?.unwrap_or_default();
+    /// ```
+    pub async fn get<T>(self, key: &str) -> crate::Result<Option<T>>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        let value = self.0.get(key).await?;
+
+        if value.is_null() {
+            return Ok(None);
+        }
+
+        let deserialized_value = serde_wasm_bindgen::from_value(self.0.get(key).await?)?;
+
+        Ok(Some(deserialized_value))
+    }
+
+    /// Returns `true` if the given `key` exists in the store.
+    ///
+    /// ```rust,no_run
+    /// use tauri_api::store::Store;
+    ///
+    /// let store = Store::new("/home/user/.local/app/settings.dat");
+    ///
+    /// let exists = store.has("dark_mode").await.unwrap_or_default();
+    /// ```
+    pub async fn has(self, key: &str) -> crate::Result<bool> {
+        Ok(serde_wasm_bindgen::from_value(self.0.has(key).await?)?)
+    }
+
+    /// Removes a key-value pair from the store.
+    pub async fn delete(self, key: &str) -> crate::Result<bool> {
+        Ok(serde_wasm_bindgen::from_value(self.0.delete(key).await?)?)
+    }
+
+    /// Clears the store, removing all key-value pairs.
+    ///
+    /// Note: To clear the storage and reset it to it's `default` value, use `reset` instead.
+    pub async fn clear(self) -> crate::Result<()> {
+        self.0.clear().await?;
+
+        Ok(())
+    }
+
+    /// Resets the store to it's `default` value.
+    ///
+    /// If no default value has been set, this method behaves identical to `clear`.
+    pub async fn reset(self) -> crate::Result<()> {
+        self.0.reset().await?;
+
+        Ok(())
+    }
+
+    /// Returns a list of all key in the store.
+    pub async fn keys(self) -> crate::Result<Vec<String>> {
+        Ok(serde_wasm_bindgen::from_value(self.0.keys().await?)?)
+    }
+
+    /// Returns a list of all values in the store.
+    ///
+    /// Note: This method returns a JsValue
+    pub async fn values(self) -> crate::Result<JsValue> {
+        Ok(self.0.values().await?)
+    }
+
+    /// Returns a list of all entries in the store.
+    ///
+    /// Note: This method returns a JsValue
+    pub async fn entries(self) -> crate::Result<JsValue> {
+        Ok(self.0.entries().await?)
+    }
+
+    /// Returns the number of key-value pairs in the store.
+    pub async fn length(self) -> crate::Result<usize> {
+        Ok(serde_wasm_bindgen::from_value(self.0.length().await?)?)
+    }
+
+    /// Attempts to load the on-disk state at the stores `path` into memory.
+    ///
+    /// This method is useful if the on-disk state was edited by the user and you want to synchronize the changes.
+    ///
+    /// Note: This method does not emit change events.
+    pub async fn load(self) -> crate::Result<()> {
+        self.0.load().await?;
+
+        Ok(())
+    }
+
+    /// Saves the store to disk at the stores `path`.
+    ///
+    /// As the store is only persisted to disk before the apps exit, changes might be lost in a crash.
+    /// This method lets you persist the store to disk whenever you deem necessary.
+    pub async fn save(self) -> crate::Result<()> {
+        self.0.save().await?;
+
+        Ok(())
+    }
+
+    /// Listen to changes on a store key.
+    ///
+    /// The returned Future will automatically clean up it's underlying event listener when dropped, so no manual unlisten function needs to be called.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tauri_api::store::Store;
+    /// use web_sys::console;
+    ///
+    /// let store = Store::new("/home/user/.local/app/settings.dat");
+    ///
+    /// let mut events = Store.on_key_change::<String>("my_value")?;
+    ///
+    /// while let Some(event) = events.next().await {
+    ///     console::log_1(&format!("New value: {}", event).into());
+    /// }
+    /// ```
+    pub async fn on_key_change<T>(self, key: &str) -> crate::Result<impl Stream<Item = T>>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded::<T>();
+
+        let closure = Closure::<dyn FnMut(JsValue)>::new(move |raw| {
+            let _ = tx.unbounded_send(serde_wasm_bindgen::from_value(raw).unwrap());
+        });
+        let unlisten = self.0.onKeyChange(key, &closure).await?;
+        closure.forget();
+
+        Ok(Listen {
+            rx,
+            unlisten: js_sys::Function::from(unlisten),
+        })
+    }
+
+    /// Listen to changes on the store.
+    ///
+    /// The returned Future will automatically clean up it's underlying event listener when dropped, so no manual unlisten function needs to be called.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tauri_api::store::Store;
+    /// use web_sys::console;
+    ///
+    /// let store = Store::new("/home/user/.local/app/settings.dat");
+    ///
+    /// let mut events = store.on_change::<String>()?;
+    ///
+    /// while let Some(event) = events.next().await {
+    ///     console::log_1(&format!("Store changed - Key: {} - Value: {}", event.key, event.value).into());
+    /// }
+    /// ```
+    pub async fn on_change<T>(self) -> crate::Result<impl Stream<Item = KeyValuePair<T>>>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded::<KeyValuePair<T>>();
+
+        let closure = Closure::<dyn FnMut(JsValue, JsValue)>::new(move |key, value| {
+            let _ = tx.unbounded_send(KeyValuePair {
+                key: serde_wasm_bindgen::from_value(key).unwrap(),
+                value: serde_wasm_bindgen::from_value(value).unwrap(),
+            });
+        });
+        let unlisten = self.0.onChange(&closure).await?;
+        closure.forget();
+
+        Ok(Listen {
+            rx,
+            unlisten: js_sys::Function::from(unlisten),
+        })
+    }
+}
+
+mod inner {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen(module = "/src/store.js")]
+    extern "C" {
+        #[derive(Debug, Clone, PartialEq)]
+        pub type Store;
+
+        #[wasm_bindgen(constructor)]
+        pub fn new(path: &str) -> Store;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn set(this: &Store, key: &str, value: JsValue) -> Result<(), JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn get(this: &Store, key: &str) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn has(this: &Store, key: &str) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn delete(this: &Store, key: &str) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn clear(this: &Store) -> Result<(), JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn reset(this: &Store) -> Result<(), JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn keys(this: &Store) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn values(this: &Store) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn entries(this: &Store) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn length(this: &Store) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn load(this: &Store) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn save(this: &Store) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn onKeyChange(
+            this: &Store,
+            key: &str,
+            handler: &Closure<dyn FnMut(JsValue)>,
+        ) -> Result<JsValue, JsValue>;
+
+        #[wasm_bindgen(method, catch)]
+        pub async fn onChange(
+            this: &Store,
+            handler: &Closure<dyn FnMut(JsValue, JsValue)>,
+        ) -> Result<JsValue, JsValue>;
+
+    }
+}

--- a/src/tauri.js
+++ b/src/tauri.js
@@ -1,5 +1,5 @@
-const convertFileSrc = window.__TAURI__.convertFileSrc;
-const invoke = window.__TAURI_INVOKE__;
-const transformCallback = window.__TAURI__.transformCallback;
+const convertFileSrc = window.__TAURI__.primitives.convertFileSrc;
+const invoke = window.__TAURI__.primitives.invoke;
+const transformCallback = window.__TAURI__.primitives.transformCallback;
 
 export { convertFileSrc, invoke, transformCallback };

--- a/src/tauri.js
+++ b/src/tauri.js
@@ -1,46 +1,5 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
-    });
-  });
-}
-function convertFileSrc(filePath, protocol = "asset") {
-  const path = encodeURIComponent(filePath);
-  return navigator.userAgent.includes("Windows") ? `https://${protocol}.localhost/${path}` : `${protocol}://localhost/${path}`;
-}
-export {
-  convertFileSrc,
-  invoke,
-  transformCallback
-};
+const convertFileSrc = window.__TAURI__.convertFileSrc;
+const invoke = window.__TAURI_INVOKE__;
+const transformCallback = window.__TAURI__.transformCallback;
+
+export { convertFileSrc, invoke, transformCallback };

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,3 +1,5 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 class Channel {
   id;
   __TAURI_CHANNEL_MARKER__ = true;
@@ -44,7 +46,7 @@ class Update {
       channel.onmessage = onEvent;
     }
 
-    return window.__TAURI_INVOKE__("plugin:updater|download_and_install", {
+    return invoke("plugin:updater|download_and_install", {
       onEvent: channel,
     });
   }
@@ -55,9 +57,7 @@ async function check(options) {
     options.headers = Array.from(new Headers(options.headers).entries());
   }
 
-  return window
-    .__TAURI_INVOKE__("plugin:updater|check", { ...options })
-    .then((meta) => (meta.available ? new Update(meta) : null));
+  return window.__TAURI_INVOKE__("plugin:updater|check", { ...options }).then((meta) => (meta.available ? new Update(meta) : null));
 }
 
 export { Update, check };

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke, transformCallback } = window.__TAURI__.primitives;
 
 class Channel {
   id;
@@ -6,7 +6,7 @@ class Channel {
   #onmessage = () => {};
 
   constructor() {
-    this.id = window.__TAURI__.transformCallback((response) => {
+    this.id = transformCallback((response) => {
       this.#onmessage(response);
     });
   }

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,185 +1,63 @@
-// tauri/tooling/api/src/tauri.ts
-function uid() {
-  return window.crypto.getRandomValues(new Uint32Array(1))[0];
-}
-function transformCallback(callback, once3 = false) {
-  const identifier = uid();
-  const prop = `_${identifier}`;
-  Object.defineProperty(window, prop, {
-    value: (result) => {
-      if (once3) {
-        Reflect.deleteProperty(window, prop);
-      }
-      return callback?.(result);
-    },
-    writable: false,
-    configurable: true
-  });
-  return identifier;
-}
-async function invoke(cmd, args = {}) {
-  return new Promise((resolve, reject) => {
-    const callback = transformCallback((e) => {
-      resolve(e);
-      Reflect.deleteProperty(window, `_${error}`);
-    }, true);
-    const error = transformCallback((e) => {
-      reject(e);
-      Reflect.deleteProperty(window, `_${callback}`);
-    }, true);
-    window.__TAURI_IPC__({
-      cmd,
-      callback,
-      error,
-      ...args
+class Channel {
+  id;
+  __TAURI_CHANNEL_MARKER__ = true;
+  #onmessage = () => {};
+
+  constructor() {
+    this.id = window.__TAURI__.transformCallback((response) => {
+      this.#onmessage(response);
     });
-  });
-}
-
-// tauri/tooling/api/src/helpers/tauri.ts
-async function invokeTauriCommand(command) {
-  return invoke("tauri", command);
-}
-
-// tauri/tooling/api/src/helpers/event.ts
-async function _unlisten(event, eventId) {
-  return invokeTauriCommand({
-    __tauriModule: "Event",
-    message: {
-      cmd: "unlisten",
-      event,
-      eventId
-    }
-  });
-}
-async function emit(event, windowLabel, payload) {
-  await invokeTauriCommand({
-    __tauriModule: "Event",
-    message: {
-      cmd: "emit",
-      event,
-      windowLabel,
-      payload
-    }
-  });
-}
-async function listen(event, windowLabel, handler) {
-  return invokeTauriCommand({
-    __tauriModule: "Event",
-    message: {
-      cmd: "listen",
-      event,
-      windowLabel,
-      handler: transformCallback(handler)
-    }
-  }).then((eventId) => {
-    return async () => _unlisten(event, eventId);
-  });
-}
-async function once(event, windowLabel, handler) {
-  return listen(event, windowLabel, (eventData) => {
-    handler(eventData);
-    _unlisten(event, eventData.id).catch(() => {
-    });
-  });
-}
-
-// tauri/tooling/api/src/event.ts
-async function listen2(event, handler) {
-  return listen(event, null, handler);
-}
-async function once2(event, handler) {
-  return once(event, null, handler);
-}
-async function emit2(event, payload) {
-  return emit(event, void 0, payload);
-}
-
-// tauri/tooling/api/src/updater.ts
-async function onUpdaterEvent(handler) {
-  return listen2("tauri://update-status" /* STATUS_UPDATE */, (data) => {
-    handler(data?.payload);
-  });
-}
-async function installUpdate() {
-  let unlistenerFn;
-  function cleanListener() {
-    if (unlistenerFn) {
-      unlistenerFn();
-    }
-    unlistenerFn = void 0;
   }
-  return new Promise((resolve, reject) => {
-    function onStatusChange(statusResult) {
-      if (statusResult.error) {
-        cleanListener();
-        return reject(statusResult.error);
-      }
-      if (statusResult.status === "DONE") {
-        cleanListener();
-        return resolve();
-      }
-    }
-    onUpdaterEvent(onStatusChange).then((fn) => {
-      unlistenerFn = fn;
-    }).catch((e) => {
-      cleanListener();
-      throw e;
-    });
-    emit2("tauri://update-install" /* INSTALL_UPDATE */).catch((e) => {
-      cleanListener();
-      throw e;
-    });
-  });
-}
-async function checkUpdate() {
-  let unlistenerFn;
-  function cleanListener() {
-    if (unlistenerFn) {
-      unlistenerFn();
-    }
-    unlistenerFn = void 0;
+
+  set onmessage(handler) {
+    this.#onmessage = handler;
   }
-  return new Promise((resolve, reject) => {
-    function onUpdateAvailable(manifest) {
-      cleanListener();
-      return resolve({
-        manifest,
-        shouldUpdate: true
-      });
-    }
-    function onStatusChange(statusResult) {
-      if (statusResult.error) {
-        cleanListener();
-        return reject(statusResult.error);
-      }
-      if (statusResult.status === "UPTODATE") {
-        cleanListener();
-        return resolve({
-          shouldUpdate: false
-        });
-      }
-    }
-    once2("tauri://update-available" /* UPDATE_AVAILABLE */, (data) => {
-      onUpdateAvailable(data?.payload);
-    }).catch((e) => {
-      cleanListener();
-      throw e;
-    });
-    onUpdaterEvent(onStatusChange).then((fn) => {
-      unlistenerFn = fn;
-    }).catch((e) => {
-      cleanListener();
-      throw e;
-    });
-    emit2("tauri://update" /* CHECK_UPDATE */).catch((e) => {
-      cleanListener();
-      throw e;
-    });
-  });
+
+  get onmessage() {
+    return this.#onmessage;
+  }
+
+  toJSON() {
+    return `__CHANNEL__:${this.id}`;
+  }
 }
-export {
-  checkUpdate,
-  installUpdate,
-  onUpdaterEvent
-};
+
+class Update {
+  available;
+  currentVersion;
+  version;
+  date;
+  body;
+
+  constructor(metadata) {
+    this.available = metadata.available;
+    this.currentVersion = metadata.currentVersion;
+    this.version = metadata.version;
+    this.date = metadata.date;
+    this.body = metadata.body;
+  }
+
+  async downloadAndInstall(onEvent) {
+    const channel = new Channel();
+
+    if (onEvent != null) {
+      channel.onmessage = onEvent;
+    }
+
+    return window.__TAURI_INVOKE__("plugin:updater|download_and_install", {
+      onEvent: channel,
+    });
+  }
+}
+
+async function check(options) {
+  if (options?.headers) {
+    options.headers = Array.from(new Headers(options.headers).entries());
+  }
+
+  return window
+    .__TAURI_INVOKE__("plugin:updater|check", { ...options })
+    .then((meta) => (meta.available ? new Update(meta) : null));
+}
+
+export { Update, check };

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,5 +1,3 @@
-use std::{cell::RefCell, rc::Rc};
-
 use futures::{channel::mpsc, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::{prelude::Closure, JsValue};

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,139 +1,83 @@
-//! Customize the auto updater flow.
+use std::{cell::RefCell, rc::Rc};
 
-use futures::{Stream, channel::mpsc};
-use serde::Deserialize;
+use futures::{channel::mpsc, Stream, StreamExt};
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::{prelude::Closure, JsValue};
-use crate::event::Listen;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateManifest {
+    pub available: bool,
     pub body: String,
+    pub current_version: String,
     pub date: String,
     pub version: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct UpdateResult {
-    pub manifest: Option<UpdateManifest>,
-    pub should_update: bool,
+#[derive(Debug, Clone, PartialEq)]
+pub struct Update(inner::Update);
+
+impl Update {
+    #[inline(always)]
+    pub async fn download_and_install(&self) -> crate::Result<impl Stream<Item = ()>> {
+        let (tx, rx) = mpsc::unbounded();
+
+        let closure = Closure::<dyn FnMut(JsValue)>::new(move |_| {
+            let _ = tx.unbounded_send(());
+        });
+
+        self.0.downloadAndInstall(&closure).await?;
+
+        closure.forget();
+
+        Ok(Listen { rx })
+    }
 }
 
-#[derive(Deserialize)]
-struct UpdateStatusResult {
-    error: Option<String>,
-    status: UpdateStatus,
-}
-
-#[derive(Deserialize)]
-pub enum UpdateStatus {
-    #[serde(rename = "PENDING")]
-    Pending,
-    #[serde(rename = "DONE")]
-    Done,
-    #[serde(rename = "UPTODATE")]
-    UpToDate,
-}
-
-/// Checks if an update is available.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// use tauri_sys::updater::check_update;
-///
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let update = check_update().await?;
-/// // now run installUpdate() if needed
-/// # Ok(())
-/// # }
-/// ```
 #[inline(always)]
-pub async fn check_update() -> crate::Result<UpdateResult> {
-    let raw = inner::checkUpdate().await?;
+pub async fn check() -> crate::Result<Update> {
+    let raw = inner::check().await?;
 
-    Ok(serde_wasm_bindgen::from_value(raw)?)
+    Ok(Update(inner::Update::new(raw)))
 }
 
-/// Install the update if there's one available.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// use tauri_sys::updater::{check_update, install_update};
-///
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let update = check_update().await?;
-///
-/// if update.should_update {
-///     log::info("Installing update {:?}", update.manifest);
-///     install_update().await?;
-/// }
-/// # Ok(())
-/// # }
-/// ```
-#[inline(always)]
-pub async fn install_update() -> crate::Result<()> {
-    inner::installUpdate().await?;
-    Ok(())
+struct Listen<T> {
+    pub rx: mpsc::UnboundedReceiver<T>,
 }
 
-/// Listen to an updater event.
-///
-/// The returned Future will automatically clean up it's underlying event listener when dropped, so no manual unlisten function needs to be called.
-/// See [Differences to the JavaScript API](../index.html#differences-to-the-javascript-api) for details.
-/// 
-/// # Example
-///
-/// ```rust,no_run
-/// use tauri_sys::updater::updater_events;
-/// use web_sys::console;
-///
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let events = updater_events();
-///
-/// while let Some(event) = events.next().await {
-///     console::log_1(&format!("Updater event {:?}", event).into());
-/// }
-/// # Ok(())
-/// # }
-/// ```
-#[inline(always)]
-pub async fn updater_events() -> crate::Result<impl Stream<Item = Result<UpdateStatus, String>>> {
-    let (tx, rx) = mpsc::unbounded::<Result<UpdateStatus, String>>();
+impl<T> Stream for Listen<T> {
+    type Item = T;
 
-    let closure = Closure::<dyn FnMut(JsValue)>::new(move |raw| {
-        let raw: UpdateStatusResult = serde_wasm_bindgen::from_value(raw).unwrap();
-
-        let msg = if let Some(error) = raw.error {
-            Err(error)
-        } else {
-            Ok(raw.status)
-        };
-
-        let _ = tx.unbounded_send(msg);
-    });
-    let unlisten = inner::onUpdaterEvent(&closure).await?;
-    closure.forget();
-
-    Ok(Listen {
-        rx,
-        unlisten: js_sys::Function::from(unlisten),
-    })
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.rx.poll_next_unpin(cx)
+    }
 }
 
 mod inner {
-    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::{
+        prelude::{wasm_bindgen, Closure},
+        JsValue,
+    };
+
+    #[wasm_bindgen(module = "/src/updater.js")]
+    extern "C" {
+        #[derive(Debug, Clone, PartialEq)]
+        pub type Update;
+        #[wasm_bindgen(constructor)]
+        pub fn new(metadata: JsValue) -> Update;
+        #[wasm_bindgen(method, catch)]
+        pub async fn downloadAndInstall(
+            this: &Update,
+            handler: &Closure<dyn FnMut(JsValue)>,
+        ) -> Result<JsValue, JsValue>;
+    }
 
     #[wasm_bindgen(module = "/src/updater.js")]
     extern "C" {
         #[wasm_bindgen(catch)]
-        pub async fn checkUpdate() -> Result<JsValue, JsValue>;
-        #[wasm_bindgen(catch)]
-        pub async fn installUpdate() -> Result<JsValue, JsValue>;
-        #[wasm_bindgen(catch)]
-        pub async fn onUpdaterEvent(
-            handler: &Closure<dyn FnMut(JsValue)>,
-        ) -> Result<JsValue, JsValue>;
+        pub async fn check() -> Result<JsValue, JsValue>;
     }
 }

--- a/src/window.js
+++ b/src/window.js
@@ -1,6 +1,8 @@
+const invoke = window.__TAURI__.primitives.invoke;
+
 // tauri/tooling/api/src/helpers/event.ts
 async function _unlisten(event, eventId) {
-  await window.__TAURI_INVOKE__("plugin:event|unlisten", {
+  await invoke("plugin:event|unlisten", {
     event,
     eventId,
   });
@@ -30,7 +32,7 @@ async function once(event, handler, options) {
 }
 
 async function emit(event, payload, options) {
-  await window.__TAURI_INVOKE__("plugin:event|emit", {
+  await invoke("plugin:event|emit", {
     event,
     windowLabel: options?.target,
     payload,
@@ -182,7 +184,7 @@ class WindowHandle {
 
 class WindowManager extends WindowHandle {
   async scaleFactor() {
-    return window.__TAURI_INVOKE__("plugin:window|scale_factor", {
+    return invoke("plugin:window|scale_factor", {
       label: this.label,
     });
   }
@@ -220,79 +222,79 @@ class WindowManager extends WindowHandle {
   }
 
   async isFullscreen() {
-    return window.__TAURI_INVOKE__("plugin:window|is_fullscreen", {
+    return invoke("plugin:window|is_fullscreen", {
       label: this.label,
     });
   }
 
   async isMinimized() {
-    return window.__TAURI_INVOKE__("plugin:window|is_minimized", {
+    return invoke("plugin:window|is_minimized", {
       label: this.label,
     });
   }
 
   async isMaximized() {
-    return window.__TAURI_INVOKE__("plugin:window|is_maximized", {
+    return invoke("plugin:window|is_maximized", {
       label: this.label,
     });
   }
 
   async isFocused() {
-    return window.__TAURI_INVOKE__("plugin:window|is_focused", {
+    return invoke("plugin:window|is_focused", {
       label: this.label,
     });
   }
 
   async isDecorated() {
-    return window.__TAURI_INVOKE__("plugin:window|is_decorated", {
+    return invoke("plugin:window|is_decorated", {
       label: this.label,
     });
   }
 
   async isResizable() {
-    return window.__TAURI_INVOKE__("plugin:window|is_resizable", {
+    return invoke("plugin:window|is_resizable", {
       label: this.label,
     });
   }
 
   async isMaximizable() {
-    return window.__TAURI_INVOKE__("plugin:window|is_maximizable", {
+    return invoke("plugin:window|is_maximizable", {
       label: this.label,
     });
   }
 
   async isMinimizable() {
-    return window.__TAURI_INVOKE__("plugin:window|is_minimizable", {
+    return invoke("plugin:window|is_minimizable", {
       label: this.label,
     });
   }
 
   async isClosable() {
-    return window.__TAURI_INVOKE__("plugin:window|is_closable", {
+    return invoke("plugin:window|is_closable", {
       label: this.label,
     });
   }
 
   async isVisible() {
-    return window.__TAURI_INVOKE__("plugin:window|is_visible", {
+    return invoke("plugin:window|is_visible", {
       label: this.label,
     });
   }
 
   async title() {
-    return window.__TAURI_INVOKE__("plugin:window|title", {
+    return invoke("plugin:window|title", {
       label: this.label,
     });
   }
 
   async theme() {
-    return window.__TAURI_INVOKE__("plugin:window|theme", {
+    return invoke("plugin:window|theme", {
       label: this.label,
     });
   }
 
   async center() {
-    return window.__TAURI_INVOKE__("plugin:window|center", {
+    return invoke("plugin:window|center", {
       label: this.label,
     });
   }
@@ -307,96 +309,96 @@ class WindowManager extends WindowHandle {
       }
     }
 
-    return window.__TAURI_INVOKE__("plugin:window|request_user_attention", {
+    return invoke("plugin:window|request_user_attention", {
       label: this.label,
       value: requestType_,
     });
   }
 
   async setResizable(resizable) {
-    return window.__TAURI_INVOKE__("plugin:window|set_resizable", {
+    return invoke("plugin:window|set_resizable", {
       label: this.label,
       value: resizable,
     });
   }
 
   async setMaximizable(maximizable) {
-    return window.__TAURI_INVOKE__("plugin:window|set_maximizable", {
+    return invoke("plugin:window|set_maximizable", {
       label: this.label,
       value: maximizable,
     });
   }
 
   async setMinimizable(minimizable) {
-    return window.__TAURI_INVOKE__("plugin:window|set_minimizable", {
+    return invoke("plugin:window|set_minimizable", {
       label: this.label,
       value: minimizable,
     });
   }
 
   async setClosable(closable) {
-    return window.__TAURI_INVOKE__("plugin:window|set_closable", {
+    return invoke("plugin:window|set_closable", {
       label: this.label,
       value: closable,
     });
   }
 
   async setTitle(title) {
-    return window.__TAURI_INVOKE__("plugin:window|set_title", {
+    return invoke("plugin:window|set_title", {
       label: this.label,
       value: title,
     });
   }
 
   async maximize() {
-    return window.__TAURI_INVOKE__("plugin:window|maximize", {
+    return invoke("plugin:window|maximize", {
       label: this.label,
     });
   }
   async unmaximize() {
-    return window.__TAURI_INVOKE__("plugin:window|unmaximize", {
+    return invoke("plugin:window|unmaximize", {
       label: this.label,
     });
   }
 
   async toggleMaximize() {
-    return window.__TAURI_INVOKE__("plugin:window|toggle_maximize", {
+    return invoke("plugin:window|toggle_maximize", {
       label: this.label,
     });
   }
 
   async minimize() {
-    return window.__TAURI_INVOKE__("plugin:window|minimize", {
+    return invoke("plugin:window|minimize", {
       label: this.label,
     });
   }
 
   async unminimize() {
-    return window.__TAURI_INVOKE__("plugin:window|unminimize", {
+    return invoke("plugin:window|unminimize", {
       label: this.label,
     });
   }
 
   async show() {
-    return window.__TAURI_INVOKE__("plugin:window|show", {
+    return invoke("plugin:window|show", {
       label: this.label,
     });
   }
 
   async hide() {
-    return window.__TAURI_INVOKE__("plugin:window|hide", {
+    return invoke("plugin:window|hide", {
       label: this.label,
     });
   }
 
   async close() {
-    return window.__TAURI_INVOKE__("plugin:window|close", {
+    return invoke("plugin:window|close", {
       label: this.label,
     });
   }
 
   async setDecorations(decorations) {
-    return window.__TAURI_INVOKE__("plugin:window|set_decorations", {
+    return invoke("plugin:window|set_decorations", {
       label: this.label,
       value: decorations,
     });
@@ -404,7 +406,7 @@ class WindowManager extends WindowHandle {
 
   // TODO:
   async setShadow(enable) {
-    return window.__TAURI_INVOKE__("plugin:window|set_shadow", {
+    return invoke("plugin:window|set_shadow", {
       label: this.label,
       value: enable,
     });
@@ -412,7 +414,7 @@ class WindowManager extends WindowHandle {
 
   // TODO:
   async setEffects(effects) {
-    return window.__TAURI_INVOKE__("plugin:window|set_effects", {
+    return invoke("plugin:window|set_effects", {
       label: this.label,
       value: effects,
     });
@@ -420,21 +422,21 @@ class WindowManager extends WindowHandle {
 
   // TODO:
   async clearEffects() {
-    return window.__TAURI_INVOKE__("plugin:window|set_effects", {
+    return invoke("plugin:window|set_effects", {
       label: this.label,
       value: null,
     });
   }
 
   async setAlwaysOnTop(alwaysOnTop) {
-    return window.__TAURI_INVOKE__("plugin:window|set_always_on_top", {
+    return invoke("plugin:window|set_always_on_top", {
       label: this.label,
       value: alwaysOnTop,
     });
   }
 
   async setContentProtected(protected_) {
-    return window.__TAURI_INVOKE__("plugin:window|set_content_protected", {
+    return invoke("plugin:window|set_content_protected", {
       label: this.label,
       value: protected_,
     });
@@ -445,7 +447,7 @@ class WindowManager extends WindowHandle {
       throw new Error("the `size` argument must be either a LogicalSize or a PhysicalSize instance");
     }
 
-    return window.__TAURI_INVOKE__("plugin:window|set_size", {
+    return invoke("plugin:window|set_size", {
       label: this.label,
       value: {
         type: size.type,
@@ -462,7 +464,7 @@ class WindowManager extends WindowHandle {
       throw new Error("the `size` argument must be either a LogicalSize or a PhysicalSize instance");
     }
 
-    return window.__TAURI_INVOKE__("plugin:window|set_min_size", {
+    return invoke("plugin:window|set_min_size", {
       label: this.label,
       value: size
         ? {
@@ -481,7 +483,7 @@ class WindowManager extends WindowHandle {
       throw new Error("the `size` argument must be either a LogicalSize or a PhysicalSize instance");
     }
 
-    return window.__TAURI_INVOKE__("plugin:window|set_max_size", {
+    return invoke("plugin:window|set_max_size", {
       label: this.label,
       value: size
         ? {
@@ -500,7 +502,7 @@ class WindowManager extends WindowHandle {
       throw new Error("the `position` argument must be either a LogicalPosition or a PhysicalPosition instance");
     }
 
-    return window.__TAURI_INVOKE__("plugin:window|set_position", {
+    return invoke("plugin:window|set_position", {
       label: this.label,
       value: {
         type: position.type,
@@ -513,48 +515,48 @@ class WindowManager extends WindowHandle {
   }
 
   async setFullscreen(fullscreen) {
-    return window.__TAURI_INVOKE__("plugin:window|set_fullscreen", {
+    return invoke("plugin:window|set_fullscreen", {
       label: this.label,
       value: fullscreen,
     });
   }
 
   async setFocus() {
-    return window.__TAURI_INVOKE__("plugin:window|set_focus", {
+    return invoke("plugin:window|set_focus", {
       label: this.label,
     });
   }
 
   async setIcon(icon) {
-    return window.__TAURI_INVOKE__("plugin:window|set_icon", {
+    return invoke("plugin:window|set_icon", {
       label: this.label,
       value: typeof icon === "string" ? icon : Array.from(icon),
     });
   }
 
   async setSkipTaskbar(skip) {
-    return window.__TAURI_INVOKE__("plugin:window|set_skip_taskbar", {
+    return invoke("plugin:window|set_skip_taskbar", {
       label: this.label,
       value: skip,
     });
   }
 
   async setCursorGrab(grab) {
-    return window.__TAURI_INVOKE__("plugin:window|set_cursor_grab", {
+    return invoke("plugin:window|set_cursor_grab", {
       label: this.label,
       value: grab,
     });
   }
 
   async setCursorVisible(visible) {
-    return window.__TAURI_INVOKE__("plugin:window|set_cursor_visible", {
+    return invoke("plugin:window|set_cursor_visible", {
       label: this.label,
       value: visible,
     });
   }
 
   async setCursorIcon(icon) {
-    return window.__TAURI_INVOKE__("plugin:window|set_cursor_icon", {
+    return invoke("plugin:window|set_cursor_icon", {
       label: this.label,
       value: icon,
     });
@@ -565,7 +567,7 @@ class WindowManager extends WindowHandle {
       throw new Error("the `position` argument must be either a LogicalPosition or a PhysicalPosition instance");
     }
 
-    return window.__TAURI_INVOKE__("plugin:window|set_cursor_position", {
+    return invoke("plugin:window|set_cursor_position", {
       label: this.label,
       value: {
         type: position.type,
@@ -578,14 +580,14 @@ class WindowManager extends WindowHandle {
   }
 
   async setIgnoreCursorEvents(ignore) {
-    return window.__TAURI_INVOKE__("plugin:window|set_ignore_cursor_events", {
+    return invoke("plugin:window|set_ignore_cursor_events", {
       label: this.label,
       value: ignore,
     });
   }
 
   async startDragging() {
-    return window.__TAURI_INVOKE__("plugin:window|start_dragging", {
+    return invoke("plugin:window|start_dragging", {
       label: this.label,
     });
   }
@@ -698,15 +700,15 @@ function mapMonitor(m) {
 }
 
 async function currentMonitor() {
-  return window.__TAURI_INVOKE__("plugin:window|current_monitor").then(mapMonitor);
+  return invoke("plugin:window|current_monitor").then(mapMonitor);
 }
 
 async function primaryMonitor() {
-  return window.__TAURI_INVOKE__("plugin:window|primary_monitor").then(mapMonitor);
+  return invoke("plugin:window|primary_monitor").then(mapMonitor);
 }
 
 async function availableMonitors() {
-  return window.__TAURI_INVOKE__("plugin:window|available_monitors").then((ms) => ms.map(mapMonitor));
+  return invoke("plugin:window|available_monitors").then((ms) => ms.map(mapMonitor));
 }
 
 export {

--- a/src/window.js
+++ b/src/window.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const { invoke, transformCallback } = window.__TAURI__.primitives;
 
 // tauri/tooling/api/src/helpers/event.ts
 async function _unlisten(event, eventId) {
@@ -9,15 +9,13 @@ async function _unlisten(event, eventId) {
 }
 
 async function listen(event, handler, options) {
-  return window
-    .__TAURI_INVOKE__("plugin:event|listen", {
-      event,
-      windowLabel: options?.target,
-      handler: window.__TAURI__.transformCallback(handler),
-    })
-    .then((eventId) => {
-      return async () => _unlisten(event, eventId);
-    });
+  return invoke("plugin:event|listen", {
+    event,
+    windowLabel: options?.target,
+    handler: transformCallback(handler),
+  }).then((eventId) => {
+    return async () => _unlisten(event, eventId);
+  });
 }
 
 async function once(event, handler, options) {
@@ -114,13 +112,13 @@ class CloseRequestedEvent {
 }
 
 function getCurrent() {
-  return new Window(window.__TAURI_METADATA__.__currentWindow.label, {
+  return new Window(window.__TAURI_INTERNALS__.currentWindow.label, {
     skip: true,
   });
 }
 
 function getAll() {
-  return window.__TAURI_METADATA__.__windows.map(
+  return window.__TAURI_INTERNALS__.windows.map(
     (w) =>
       new Window(w.label, {
         skip: true,


### PR DESCRIPTION
The changes is mostly in the JS code that needs to be updated so it can use `window`'s invoke.

There are still missing new plugins and other plugins that need work, specially `upload` and `updater`, and others that need to be updated to v2.