### PR TITLE
Fix/wasm bindgen serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde-wasm-bindgen = "0.6.3"
 serde_repr = "0.1.17"
 thiserror = "1.0.50"
 url = {version = "2.5.0", optional = true, features = ["serde"]}
-wasm-bindgen = {version = "0.2.89", features = ["serde_json"]}
+wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.39"
 
 [dev-dependencies]

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -73,7 +73,7 @@ async fn test_get_version() {
         Ok("1.0.0")
     });
 
-    let version = get_version().await;
+    let version = get_version().await.unwrap();
 
     assert_eq!(version.major, 1);
     assert_eq!(version.minor, 0);


### PR DESCRIPTION
Fix Issue #52, resolving the dependency on `wasm-bindgen-serde`.